### PR TITLE
New branch removing quick-start folder

### DIFF
--- a/bucket/Kptfile
+++ b/bucket/Kptfile
@@ -1,0 +1,43 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: bucket
+openAPI:
+  definitions:
+    io.k8s.cli.setters.name:
+      x-k8s-cli:
+        setter:
+          name: name
+          value: bucket
+          required: true
+      description: Bucket instance name
+    io.k8s.cli.setters.storage-class:
+      x-k8s-cli:
+        setter:
+          name: storage-class
+          value: standard
+      description: Bucket storage class
+    io.k8s.cli.substitutions.bucket-name:
+      x-k8s-cli:
+        substitution:
+          name: bucket-name
+          pattern: ${PROJECT_ID}-${NAME}
+          values:
+          - marker: ${PROJECT_ID}
+            ref: '#/definitions/io.k8s.cli.setters.project-id'
+          - marker: ${NAME}
+            ref: '#/definitions/io.k8s.cli.setters.name'
+    io.k8s.cli.setters.project-id:
+      x-k8s-cli:
+        setter:
+          name: project-id
+          value: $DEFAULT_PROJECT
+          required: true
+      description: Project ID for bucket instance
+    io.k8s.cli.setters.namespace: 
+      x-k8s-cli:
+        setter:
+          name: namespace
+          value: config-controller-system
+      description: Namespace name for pipeline resources
+

--- a/bucket/README.md
+++ b/bucket/README.md
@@ -1,0 +1,4 @@
+# Google Cloud Storage bucket blueprint
+
+This blueprint deploys a single bucket into Google Cloud
+

--- a/bucket/bucket.yaml
+++ b/bucket/bucket.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  name: blueprints-project-bucket # {"$ref":"#/definitions/io.k8s.cli.substitutions.bucket-name"}
+  namespace: config-controller-system # {"$kpt-set":"namespace"}
+  annotations:
+    cnrm.cloud.google.com/project-id: blueprints-project # {"$kpt-set":"project-id"}
+    cnrm.cloud.google.com/force-destroy: "false"
+spec:
+  storageClass: standard # {"$kpt-set":"storage-class"}
+  uniformBucketLevelAccess: true
+  versioning:
+    enabled: false

--- a/redis-bucket/Kptfile
+++ b/redis-bucket/Kptfile
@@ -1,0 +1,64 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: redis-bucket
+openAPI:
+  definitions:
+    io.k8s.cli.setters.name:
+      x-k8s-cli:
+        setter:
+          name: name
+          value: redis-bucket
+          required: true
+      description: instance name
+    io.k8s.cli.substitutions.networkref:
+      x-k8s-cli:
+        substitution:
+          name: networkref
+          pattern: projects/${PROJECT_ID}/global/networks/${NETWORK}
+          values:
+          - marker: ${PROJECT_ID}
+            ref: '#/definitions/io.k8s.cli.setters.project-id'
+          - marker: ${NETWORK}
+            ref: '#/definitions/io.k8s.cli.setters.network'
+    io.k8s.cli.substitutions.redis-bucket-name:
+      x-k8s-cli:
+        substitution:
+          name: services-redis
+          pattern: ${PROJECT_ID}-${NAME}
+          values:
+          - marker: ${PROJECT_ID}
+            ref: '#/definitions/io.k8s.cli.setters.project-id'
+          - marker: ${NAME}
+            ref: '#/definitions/io.k8s.cli.setters.name'
+    io.k8s.cli.setters.storage-class:
+      x-k8s-cli:
+        setter:
+          name: storage-class
+          value: standard
+      description: Bucket storage class
+    io.k8s.cli.setters.network:
+      x-k8s-cli:
+        setter:
+          name: network
+          value: default
+      description: instance network
+    io.k8s.cli.setters.region:
+      x-k8s-cli:
+        setter:
+          name: region
+          value: us-central1
+      description: instance region
+    io.k8s.cli.setters.project-id:
+      x-k8s-cli:
+        setter:
+          name: project-id
+          value: $DEFAULT_PROJECT
+          required: true
+      description: Project ID for instance
+    io.k8s.cli.setters.namespace:
+      x-k8s-cli:
+        setter:
+          name: namespace
+          value: config-controller-system
+      description: Namespace name for pipeline resources

--- a/redis-bucket/README.md
+++ b/redis-bucket/README.md
@@ -1,0 +1,4 @@
+# Google Cloud Redis and Storage bucket blueprint
+
+This blueprint deploys a Redis instance and storage bucket into Google Cloud
+

--- a/redis-bucket/bucket.yaml
+++ b/redis-bucket/bucket.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  name: blueprints-project-redis-bucket # {"$ref":"#/definitions/io.k8s.cli.substitutions.redis-bucket-name"}
+  namespace: config-controller-system # {"$kpt-set":"namespace"}
+  annotations:
+    cnrm.cloud.google.com/project-id: blueprints-project # {"$kpt-set":"project-id"}
+    cnrm.cloud.google.com/force-destroy: "false"
+spec:
+  storageClass: standard # {"$kpt-set":"storage-class"}
+  uniformBucketLevelAccess: true
+  versioning:
+    enabled: false

--- a/redis-bucket/redis.yaml
+++ b/redis-bucket/redis.yaml
@@ -1,0 +1,25 @@
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: blueprints-project-redis-bucket # {"$ref":"#/definitions/io.k8s.cli.substitutions.redis-bucket-name"}
+  namespace: config-controller-system # {"$kpt-set":"namespace"}
+  annotations:
+    cnrm.cloud.google.com/project-id: blueprints-project # {"$kpt-set":"project-id"}
+    cnrm.cloud.google.com/disable-on-destroy: "false"
+spec:
+  resourceID: redis.googleapis.com
+---
+apiVersion: redis.cnrm.cloud.google.com/v1beta1
+kind: RedisInstance
+metadata:
+  name: blueprints-project-redis-bucket # {"$ref":"#/definitions/io.k8s.cli.substitutions.redis-bucket-name"}
+  namespace: config-controller-system # {"$kpt-set":"namespace"}
+  annotations:
+    cnrm.cloud.google.com/project-id: blueprints-project # {"$kpt-set":"project-id"}
+spec:
+  authorizedNetworkRef:
+    external: projects/blueprints-project/global/networks/default # {"$ref":"#/definitions/io.k8s.cli.substitutions.networkref"}
+  displayName: blueprints-project-redis-bucket # {"$ref":"#/definitions/io.k8s.cli.substitutions.redis-bucket-name"}
+  memorySizeGb: 3
+  region: us-central1 # {"$kpt-set":"region"}
+  tier: BASIC


### PR DESCRIPTION
Incorporates Morgante's feedback from Friday.  This is a new branch/PR that places the two blueprints directly into the blueprints folder without a quick-start folder.