### PR TITLE
An empty blueprint

### DIFF
--- a/catalog/empty/Kptfile
+++ b/catalog/empty/Kptfile
@@ -1,0 +1,6 @@
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: empty
+info:
+  description: An empty blueprint

--- a/catalog/empty/README.md
+++ b/catalog/empty/README.md
@@ -1,0 +1,4 @@
+# An empty blueprint
+
+This is an example of an empty blueprint.
+

--- a/catalog/empty/noop.yaml
+++ b/catalog/empty/noop.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: noop
+  namespace: config-control
+  annotations:
+    config.kubernetes.io/local-config: "true"


### PR DESCRIPTION
The empty blueprint contains a `local-config` config map
to work around an issue. This will be removed in the near future.