### PR TITLE
fix: only specify immediate setters in subnet setters.yaml

### DIFF
--- a/catalog/networking/network/subnet/setters.yaml
+++ b/catalog/networking/network/subnet/setters.yaml
@@ -3,10 +3,5 @@ kind: ConfigMap
 metadata:
   name: setters
 data:
-  namespace: networking
   ip-cidr-range: 10.2.0.0/16
-  network-name: network-name
-  project-id: project-id
-  region: us-central1
   source-subnetwork-ip-ranges-to-nat: ALL_SUBNETWORKS_ALL_IP_RANGES
-  prefix: ""


### PR DESCRIPTION
This is a better workaround for https://github.com/GoogleCloudPlatform/blueprints/issues/28 which prevents duplication.

Fixes #28.