### PR TITLE
Change syncBranch to master branch

### DIFF
--- a/catalog/gitops/configsync/config-management.yaml
+++ b/catalog/gitops/configsync/config-management.yaml
@@ -11,7 +11,7 @@ spec:
     gcpServiceAccountEmail: sync-cluster-name@project-id.iam.gserviceaccount.com # kpt-set: sync-${cluster-name}@${project-id}.iam.gserviceaccount.com
     policyDir: config # kpt-set: ${configsync-dir}
     secretType: gcpserviceaccount
-    syncBranch: main
+    syncBranch: master
     syncRepo: https://source.developers.google.com/p/project-id/r/deployment-repo # kpt-set: https://source.developers.google.com/p/${project-id}/r/${deployment-repo}
     syncRevision: HEAD
   sourceFormat: unstructured


### PR DESCRIPTION
Changed sync branch to `master` branch since CSR default isn't `main`.