### PR TITLE
Add fix-attribution.sh script [DO NOT MERGE]

### DIFF
--- a/catalog/bucket/bucket.yaml
+++ b/catalog/bucket/bucket.yaml
@@ -19,6 +19,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/force-destroy: "false"
     cnrm.cloud.google.com/project-id: blueprints-project # kpt-set: ${project-id}
+    cnrm.cloud.google.com/blueprint: cnrm/bucket/v0.2.0
 spec:
   storageClass: standard # kpt-set: ${storage-class}
   uniformBucketLevelAccess: true

--- a/catalog/gitops/cloudbuild-iam.yaml
+++ b/catalog/gitops/cloudbuild-iam.yaml
@@ -18,7 +18,7 @@ metadata:
   name: deployment-repo-cloudbuild-write
   namespace: config-control # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gitops/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/gitops-csr/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
   member: serviceAccount:1234567890123@cloudbuild.gserviceaccount.com # kpt-set: serviceAccount:${project-number}@cloudbuild.gserviceaccount.com
@@ -35,7 +35,7 @@ metadata:
   name: source-repo-cloudbuild-read
   namespace: config-control # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gitops/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/gitops-csr/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
   member: serviceAccount:1234567890123@cloudbuild.gserviceaccount.com # kpt-set: serviceAccount:${project-number}@cloudbuild.gserviceaccount.com

--- a/catalog/gitops/configsync/config-management.yaml
+++ b/catalog/gitops/configsync/config-management.yaml
@@ -17,6 +17,8 @@ apiVersion: configmanagement.gke.io/v1
 kind: ConfigManagement
 metadata:
   name: config-management
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/gitops-csr:configsync-csr/v0.2.0
 spec:
   clusterName: cluster-name # kpt-set: ${cluster-name}
   enableMultiRepo: false

--- a/catalog/gitops/configsync/configsync-iam.yaml
+++ b/catalog/gitops/configsync/configsync-iam.yaml
@@ -19,7 +19,7 @@ metadata:
   name: sync-cluster-name # kpt-set: sync-${cluster-name}
   namespace: config-control # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gitops/configsync/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/gitops-csr:configsync-csr/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
   displayName: sync-cluster-name # kpt-set: sync-${cluster-name}
@@ -31,7 +31,7 @@ metadata:
   name: sync-cluster-name # kpt-set: sync-${cluster-name}
   namespace: config-control # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gitops/configsync/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/gitops-csr:configsync-csr/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
   member: serviceAccount:project-id.svc.id.goog[config-management-system/importer] # kpt-set: serviceAccount:${project-id}.svc.id.goog[config-management-system/importer]
@@ -48,7 +48,7 @@ metadata:
   name: source-reader-sync-cluster-name-project-id # kpt-set: source-reader-sync-${cluster-name}-${project-id}
   namespace: config-control # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gitops/configsync/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/gitops-csr:configsync-csr/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
   member: serviceAccount:sync-cluster-name@project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:sync-${cluster-name}@${project-id}.iam.gserviceaccount.com

--- a/catalog/gitops/hydration-trigger.yaml
+++ b/catalog/gitops/hydration-trigger.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # Trigger for when changes are pushed into any branch of the yakima source repo.
 # This will run all your kpt functions and apply a blast radius analysis of
 # changes.
@@ -22,7 +21,7 @@ metadata:
   name: source-repo-cicd-trigger # kpt-set: ${source-repo}-cicd-trigger
   namespace: config-control # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gitops/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/gitops-csr/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
   build:
@@ -32,7 +31,7 @@ spec:
           - name: deployment-workspace
             path: /deployment-workspace
         args:
-          - '-c'
+          - -c
           - |
             set -e
             gcloud source repos clone $_DEPLOYMENT_REPO .
@@ -41,14 +40,14 @@ spec:
             mkdir -p /deployment-workspace/config
         dir: /deployment-workspace
         entrypoint: /bin/sh
-        id: "Clone Deployment Repo"
+        id: Clone Deployment Repo
         timeout: 300s
       - name: gcr.io/kpt-dev/kpt:v1.0.0-beta.1
         volumes:
           - name: hydrated-workspace
             path: /hydrated-workspace
         args:
-          - '-c'
+          - -c
           - |
             set -eo pipefail
             SRC_DIR="."
@@ -63,7 +62,7 @@ spec:
             echo "Removing local config"
             kpt fn eval "$${DEST_DIR}" -i gcr.io/yakima-eap/remove-annotated-resources:v0.1
         entrypoint: /bin/bash
-        id: "Apply Hydration and Validation"
+        id: Apply Hydration and Validation
       - name: gcr.io/cloud-builders/gcloud:latest
         volumes:
           - name: hydrated-workspace
@@ -71,7 +70,7 @@ spec:
           - name: deployment-workspace
             path: /deployment-workspace
         args:
-          - '-c'
+          - -c
           - |
             set -e
             git pull origin $BRANCH_NAME || true # Ignore errors in case branch doesn't exist
@@ -87,17 +86,17 @@ spec:
             printf "\n\nLatest deployment repo commit SHA: $(git rev-parse HEAD)\n"
         dir: /deployment-workspace
         entrypoint: /bin/sh
-        id: "Push Changes To Deployment Repo"
+        id: Push Changes To Deployment Repo
         waitFor:
-          - "Apply Hydration and Validation"
+          - Apply Hydration and Validation
     timeout: 600s
   description: Cloud Build Trigger for rendering from the soure repo to the deployment repo.
   disabled: false
   substitutions:
-    "_ADMIN_CLUSTER_NAME": "cluster-name" # kpt-set: ${cluster-name}
-    "_DEPLOYMENT_REPO": "deployment-repo" # kpt-set: ${deployment-repo}
-    "_SOURCE_REPO": "source-repo" # kpt-set: ${source-repo}
+    _ADMIN_CLUSTER_NAME: cluster-name # kpt-set: ${cluster-name}
+    _DEPLOYMENT_REPO: deployment-repo # kpt-set: ${deployment-repo}
+    _SOURCE_REPO: source-repo # kpt-set: ${source-repo}
   triggerTemplate:
-    branchName: ".*"
+    branchName: .*
     repoRef:
       name: source-repo # kpt-set: ${source-repo}

--- a/catalog/gitops/services.yaml
+++ b/catalog/gitops/services.yaml
@@ -17,7 +17,7 @@ metadata:
   name: sourcerepo.googleapis.com
   namespace: config-control # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gitops/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/gitops-csr/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 ---
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
@@ -26,5 +26,5 @@ metadata:
   name: cloudbuild.googleapis.com
   namespace: config-control # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gitops/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/gitops-csr/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}

--- a/catalog/gitops/source-repositories.yaml
+++ b/catalog/gitops/source-repositories.yaml
@@ -17,7 +17,7 @@ metadata:
   name: source-repo # kpt-set: ${source-repo}
   namespace: config-control # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gitops/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/gitops-csr/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 ---
 apiVersion: sourcerepo.cnrm.cloud.google.com/v1beta1
@@ -26,5 +26,5 @@ metadata:
   name: deployment-repo # kpt-set: ${deployment-repo}
   namespace: config-control # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gitops/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/gitops-csr/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}

--- a/catalog/gke/subnet/subnet.yaml
+++ b/catalog/gke/subnet/subnet.yaml
@@ -23,7 +23,7 @@ metadata:
   name: platform-project-id-example-us-east4 # kpt-set: ${platform-project-id}-${cluster-name}
   namespace: networking # kpt-set: ${networking-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gke:gke-subnet/v0.2.0-alpha.1
+    cnrm.cloud.google.com/blueprint: cnrm/gke:gke-subnet/v0.2.0
     cnrm.cloud.google.com/project-id: network-project-id # kpt-set: ${network-project-id}
 spec:
   description: platform-project-id-example-us-east4 # kpt-set: ${platform-project-id}-${cluster-name}

--- a/catalog/hierarchy/bu/policies/naming-constraint.yaml
+++ b/catalog/hierarchy/bu/policies/naming-constraint.yaml
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GCPEnforceNamingV2
 metadata:
   name: enforce-folder-names
   annotations:
     description: Checks that folder names follow the required standard.
+    cnrm.cloud.google.com/blueprint: cnrm/bu-hierarchy/v0.2.0
 spec:
   parameters:
     naming_rules:

--- a/catalog/hierarchy/env-bu/policies/naming-constraint.yaml
+++ b/catalog/hierarchy/env-bu/policies/naming-constraint.yaml
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GCPEnforceNamingV2
 metadata:
   name: enforce-folder-names
   annotations:
     description: Checks that folder names follow the required standard.
+    cnrm.cloud.google.com/blueprint: cnrm/env-bu-hierarchy/v0.2.0
 spec:
   parameters:
     naming_rules:

--- a/catalog/hierarchy/env-bu/shared-folders.yaml
+++ b/catalog/hierarchy/env-bu/shared-folders.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: Folder
 metadata:
   name: dev.shared
   namespace: hierarchy # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:hierarchy:env-bu/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/env-bu-hierarchy/v0.2.0
 spec:
   displayName: shared
   folderRef:
@@ -30,7 +29,7 @@ metadata:
   name: prod.shared
   namespace: hierarchy # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:hierarchy:env-bu/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/env-bu-hierarchy/v0.2.0
 spec:
   displayName: shared
   folderRef:

--- a/catalog/hierarchy/simple/policies/naming-constraint.yaml
+++ b/catalog/hierarchy/simple/policies/naming-constraint.yaml
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GCPEnforceNamingV2
 metadata:
   name: enforce-folder-names
   annotations:
     description: Checks that folder names follow the required standard.
+    cnrm.cloud.google.com/blueprint: cnrm/simple-hierarchy/v0.2.0
 spec:
   parameters:
     naming_rules:

--- a/catalog/hierarchy/team/policies/naming-constraint.yaml
+++ b/catalog/hierarchy/team/policies/naming-constraint.yaml
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GCPEnforceNamingV2
 metadata:
   name: enforce-folder-names
   annotations:
     description: Checks that folder names follow the required standard.
+    cnrm.cloud.google.com/blueprint: cnrm/team-hierarchy/v0.2.0
 spec:
   parameters:
     naming_rules:

--- a/catalog/landing-zone/iam.yaml
+++ b/catalog/landing-zone/iam.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:

--- a/catalog/landing-zone/namespaces/hierarchy.yaml
+++ b/catalog/landing-zone/namespaces/hierarchy.yaml
@@ -31,7 +31,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:hierarchy-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:hierarchy-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:hierarchy-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:hierarchy-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -59,6 +59,8 @@ kind: RoleBinding
 metadata:
   name: allow-resource-reference-from-hierarchy
   namespace: hierarchy
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 roleRef:
   name: cnrm-viewer
   kind: ClusterRole
@@ -74,6 +76,7 @@ metadata:
   name: hierarchy
   annotations:
     cnrm.cloud.google.com/organization-id: "123456789012" # kpt-set: ${org-id}
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 ---
 apiVersion: core.cnrm.cloud.google.com/v1beta1
 kind: ConfigConnectorContext

--- a/catalog/landing-zone/namespaces/logging.yaml
+++ b/catalog/landing-zone/namespaces/logging.yaml
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: Namespace
 metadata:
   name: logging
   annotations:
     cnrm.cloud.google.com/organization-id: "123456789012" # kpt-set: ${org-id}
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 ---
 apiVersion: core.cnrm.cloud.google.com/v1beta1
 kind: ConfigConnectorContext
@@ -49,7 +49,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -65,7 +65,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -93,6 +93,8 @@ kind: RoleBinding
 metadata:
   name: allow-resource-reference-from-logging
   namespace: projects
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 roleRef:
   name: cnrm-viewer
   kind: ClusterRole

--- a/catalog/landing-zone/namespaces/networking.yaml
+++ b/catalog/landing-zone/namespaces/networking.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
@@ -32,7 +31,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -48,7 +47,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -64,7 +63,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -80,7 +79,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -96,7 +95,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -125,12 +124,15 @@ metadata:
   name: networking
   annotations:
     cnrm.cloud.google.com/organization-id: "123456789012" # kpt-set: ${org-id}
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: allow-resource-reference-from-networking
   namespace: projects
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 roleRef:
   name: cnrm-viewer
   kind: ClusterRole

--- a/catalog/landing-zone/namespaces/policies.yaml
+++ b/catalog/landing-zone/namespaces/policies.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
@@ -32,7 +31,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:policies-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:policies-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:policies-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:policies-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -61,6 +60,7 @@ metadata:
   name: policies
   annotations:
     cnrm.cloud.google.com/organization-id: "123456789012" # kpt-set: ${org-id}
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 ---
 apiVersion: core.cnrm.cloud.google.com/v1beta1
 kind: ConfigConnectorContext

--- a/catalog/landing-zone/namespaces/projects.yaml
+++ b/catalog/landing-zone/namespaces/projects.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
@@ -32,7 +31,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -48,7 +47,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -64,7 +63,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -80,7 +79,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -96,7 +95,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
@@ -125,11 +124,14 @@ metadata:
   name: projects
   annotations:
     cnrm.cloud.google.com/organization-id: "123456789012" # kpt-set: ${org-id}
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 ---
 apiVersion: core.cnrm.cloud.google.com/v1beta1
 kind: ConfigConnectorContext
 metadata:
   name: configconnectorcontext.core.cnrm.cloud.google.com
   namespace: projects
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 spec:
   googleServiceAccount: projects-sa@management-project-id.iam.gserviceaccount.com # kpt-set: projects-sa@${management-project-id}.iam.gserviceaccount.com

--- a/catalog/landing-zone/policies/deletion-policy-required-template.yaml
+++ b/catalog/landing-zone/policies/deletion-policy-required-template.yaml
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: gcprequiredeletionpolicy
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 spec:
   crd:
     spec:
@@ -23,7 +24,7 @@ spec:
         kind: GCPRequireDeletionPolicy
       validation:
         openAPIV3Schema:
-          properties:
+          properties: null
   targets:
     - rego: |
         package templates.gcp.GCPRequireDeletionPolicyConstraint

--- a/catalog/landing-zone/policies/disable-guest-attributes.yaml
+++ b/catalog/landing-zone/policies/disable-guest-attributes.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
@@ -22,6 +21,6 @@ metadata:
 spec:
   booleanPolicy:
     enforced: true
-  constraint: "constraints/compute.disableGuestAttributesAccess"
+  constraint: constraints/compute.disableGuestAttributesAccess
   organizationRef:
     external: "123456789012" # kpt-set: ${org-id}

--- a/catalog/landing-zone/policies/disable-nested-virtualization.yaml
+++ b/catalog/landing-zone/policies/disable-nested-virtualization.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
@@ -22,6 +21,6 @@ metadata:
 spec:
   booleanPolicy:
     enforced: true
-  constraint: "constraints/compute.disableNestedVirtualization"
+  constraint: constraints/compute.disableNestedVirtualization
   organizationRef:
     external: "123456789012" # kpt-set: ${org-id}

--- a/catalog/landing-zone/policies/disable-sa-key-creation.yaml
+++ b/catalog/landing-zone/policies/disable-sa-key-creation.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
@@ -22,6 +21,6 @@ metadata:
 spec:
   booleanPolicy:
     enforced: true
-  constraint: "constraints/iam.disableServiceAccountKeyCreation"
+  constraint: constraints/iam.disableServiceAccountKeyCreation
   organizationRef:
     external: "123456789012" # kpt-set: ${org-id}

--- a/catalog/landing-zone/policies/disable-serial-port.yaml
+++ b/catalog/landing-zone/policies/disable-serial-port.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
@@ -22,6 +21,6 @@ metadata:
 spec:
   booleanPolicy:
     enforced: true
-  constraint: "constraints/compute.disableSerialPortAccess"
+  constraint: constraints/compute.disableSerialPortAccess
   organizationRef:
     external: "123456789012" # kpt-set: ${org-id}

--- a/catalog/landing-zone/policies/disable-vm-external-ip.yaml
+++ b/catalog/landing-zone/policies/disable-vm-external-ip.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
@@ -20,7 +19,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 spec:
-  constraint: "constraints/compute.vmExternalIpAccess"
+  constraint: constraints/compute.vmExternalIpAccess
   listPolicy:
     deny:
       all: true

--- a/catalog/landing-zone/policies/enforce-uniform-bucket-lvl-access.yaml
+++ b/catalog/landing-zone/policies/enforce-uniform-bucket-lvl-access.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
@@ -22,6 +21,6 @@ metadata:
 spec:
   booleanPolicy:
     enforced: true
-  constraint: "constraints/storage.uniformBucketLevelAccess"
+  constraint: constraints/storage.uniformBucketLevelAccess
   organizationRef:
     external: "123456789012" # kpt-set: ${org-id}

--- a/catalog/landing-zone/policies/folder-naming-constraint-template.yaml
+++ b/catalog/landing-zone/policies/folder-naming-constraint-template.yaml
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: gcpenforcenamingv2
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
 spec:
   crd:
     spec:

--- a/catalog/landing-zone/policies/restrict-cloud-sql-public-ip.yaml
+++ b/catalog/landing-zone/policies/restrict-cloud-sql-public-ip.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
@@ -22,6 +21,6 @@ metadata:
 spec:
   booleanPolicy:
     enforced: true
-  constraint: "constraints/sql.restrictPublicIp"
+  constraint: constraints/sql.restrictPublicIp
   organizationRef:
     external: "123456789012" # kpt-set: ${org-id}

--- a/catalog/landing-zone/policies/restrict-lien-removal.yaml
+++ b/catalog/landing-zone/policies/restrict-lien-removal.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
@@ -22,6 +21,6 @@ metadata:
 spec:
   booleanPolicy:
     enforced: true
-  constraint: "constraints/compute.restrictXpnProjectLienRemoval"
+  constraint: constraints/compute.restrictXpnProjectLienRemoval
   organizationRef:
     external: "123456789012" # kpt-set: ${org-id}

--- a/catalog/landing-zone/policies/skip-default-network.yaml
+++ b/catalog/landing-zone/policies/skip-default-network.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: ResourceManagerPolicy
 metadata:
@@ -22,6 +21,6 @@ metadata:
 spec:
   booleanPolicy:
     enforced: true
-  constraint: "constraints/compute.skipDefaultNetworkCreation"
+  constraint: constraints/compute.skipDefaultNetworkCreation
   organizationRef:
     external: "123456789012" # kpt-set: ${org-id}

--- a/catalog/landing-zone/services.yaml
+++ b/catalog/landing-zone/services.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
@@ -19,7 +18,7 @@ metadata:
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.2.0
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/deletion-policy: abandon
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceID: cloudbilling.googleapis.com

--- a/catalog/log-export/folder/bigquery-export/export.yaml
+++ b/catalog/log-export/folder/bigquery-export/export.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # API Activation
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
@@ -19,7 +18,7 @@ metadata:
   name: my-project-id-bigquery # kpt-set: ${project-id}-bigquery
   namespace: projects
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/bigquery-export/v0.2.0
     cnrm.cloud.google.com/deletion-policy: abandon
     cnrm.cloud.google.com/disable-dependent-services: "false"
     cnrm.cloud.google.com/project-id: my-project-id # kpt-set: ${project-id}
@@ -33,7 +32,7 @@ metadata:
   name: my.folder.k8s.name-bqsink # kpt-set: ${folder-k8s-name}-bqsink
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/bigquery-export/v0.2.0
 spec:
   destination:
     bigQueryDatasetRef:
@@ -50,10 +49,10 @@ metadata:
   name: bqlogexportdataset
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/bigquery-export/v0.2.0
     cnrm.cloud.google.com/delete-contents-on-destroy: "false" # kpt-set: ${delete-contents-on-destroy}
 spec:
   defaultTableExpirationMs: 3600000 # kpt-set: ${default-table-expiration-ms}
-  description: "BigQuery audit logs for folder" # kpt-set: ${dataset-description}
+  description: BigQuery audit logs for folder # kpt-set: ${dataset-description}
   friendlyName: audit-logs # kpt-set: ${dataset-name}
   location: US # kpt-set: ${dataset-location}

--- a/catalog/log-export/folder/bigquery-export/iam.yaml
+++ b/catalog/log-export/folder/bigquery-export/iam.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # IAM Policy Member
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -19,7 +18,7 @@ metadata:
   name: bq-project-iam-policy
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/bigquery-export/v0.2.0
 spec:
   memberFrom:
     logSinkRef:

--- a/catalog/log-export/folder/pubsub-export/export.yaml
+++ b/catalog/log-export/folder/pubsub-export/export.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # API Activation
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
@@ -19,8 +18,8 @@ metadata:
   name: my-project-id-pubsub # kpt-set: ${project-id}-pubsub
   namespace: projects
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/blueprint: cnrm/pubsub-export/v0.2.0
+    cnrm.cloud.google.com/deletion-policy: abandon
     cnrm.cloud.google.com/disable-dependent-services: "false"
     cnrm.cloud.google.com/project-id: my-project-id # kpt-set: ${project-id}
 spec:
@@ -33,7 +32,7 @@ metadata:
   name: my.folder.k8s.name-pubsubsink # kpt-set: ${folder-k8s-name}-pubsubsink
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/pubsub-export/v0.2.0
 spec:
   destination:
     pubSubTopicRef:
@@ -49,5 +48,7 @@ kind: PubSubTopic
 metadata:
   name: pubsub-logexport-dataset # kpt-set: ${topic-name}
   namespace: my-namespace # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/pubsub-export/v0.2.0
 
 # TODO(jcwc): Add support for creating subscribers (either a new blueprint or kpt fn)

--- a/catalog/log-export/folder/pubsub-export/iam.yaml
+++ b/catalog/log-export/folder/pubsub-export/iam.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # IAM Policy Member
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -19,7 +18,7 @@ metadata:
   name: pubsub-iam-policy
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/pubsub-export/v0.2.0
 spec:
   memberFrom:
     logSinkRef:

--- a/catalog/log-export/folder/storage-export/export.yaml
+++ b/catalog/log-export/folder/storage-export/export.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # API Activation
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
@@ -19,8 +18,8 @@ metadata:
   name: my-project-id-storage # kpt-set: ${project-id}-storage
   namespace: projects
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/blueprint: cnrm/storage-export/v0.2.0
+    cnrm.cloud.google.com/deletion-policy: abandon
     cnrm.cloud.google.com/disable-dependent-services: "false"
     cnrm.cloud.google.com/project-id: my-project-id # kpt-set: ${project-id}
 spec:
@@ -33,7 +32,7 @@ metadata:
   name: my.folder.k8s.name-storagesink # kpt-set: ${folder-k8s-name}-storagesink
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/storage-export/v0.2.0
 spec:
   destination:
     storageBucketRef:
@@ -51,6 +50,7 @@ metadata:
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/force-destroy: "true"
+    cnrm.cloud.google.com/blueprint: cnrm/storage-export/v0.2.0
 spec:
   bucketPolicyOnly: false # kpt-set: ${bucket-policy-only}
   location: US # kpt-set: ${location}

--- a/catalog/log-export/folder/storage-export/iam.yaml
+++ b/catalog/log-export/folder/storage-export/iam.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # IAM Policy Member
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -19,7 +18,7 @@ metadata:
   name: storage-project-iam-policy
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/storage-export/v0.2.0
 spec:
   memberFrom:
     logSinkRef:

--- a/catalog/log-export/org/bigquery-export/export.yaml
+++ b/catalog/log-export/org/bigquery-export/export.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # API Activation
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
@@ -19,8 +18,8 @@ metadata:
   name: my-project-id-bigquery # kpt-set: ${project-id}-bigquery
   namespace: projects
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/blueprint: cnrm/bigquery-export/v0.2.0
+    cnrm.cloud.google.com/deletion-policy: abandon
     cnrm.cloud.google.com/disable-dependent-services: "false"
     cnrm.cloud.google.com/project-id: my-project-id # kpt-set: ${project-id}
 spec:
@@ -33,7 +32,7 @@ metadata:
   name: 123456789012-bqsink # kpt-set: ${org-id}-bqsink
   namespace: logging # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/bigquery-export/v0.2.0
 spec:
   destination:
     bigQueryDatasetRef:
@@ -52,9 +51,9 @@ metadata:
   annotations:
     cnrm.cloud.google.com/delete-contents-on-destroy: "false" # kpt-set: ${delete-contents-on-destroy}
     cnrm.cloud.google.com/project-id: my-project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/bigquery-export/v0.2.0
 spec:
   defaultTableExpirationMs: 3600000 # kpt-set: ${default-table-expiration-ms}
-  description: "BigQuery audit logs for folder" # kpt-set: ${dataset-description}
+  description: BigQuery audit logs for folder # kpt-set: ${dataset-description}
   friendlyName: audit-logs # kpt-set: ${dataset-name}
   location: US # kpt-set: ${dataset-location}

--- a/catalog/log-export/org/bigquery-export/iam.yaml
+++ b/catalog/log-export/org/bigquery-export/iam.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # IAM Policy Member
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -19,7 +18,7 @@ metadata:
   name: bq-project-iam-policy
   namespace: logging # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/bigquery-export/v0.2.0
 spec:
   memberFrom:
     logSinkRef:
@@ -36,9 +35,9 @@ metadata:
   name: logging-sa-iam-permissions
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/bigquery-export/v0.2.0
 spec:
-  member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
+  member: serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project

--- a/catalog/log-export/org/pubsub-export/export.yaml
+++ b/catalog/log-export/org/pubsub-export/export.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # API Activation
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
@@ -19,8 +18,8 @@ metadata:
   name: my-project-id-pubsub # kpt-set: ${project-id}-pubsub
   namespace: projects
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/blueprint: cnrm/pubsub-export/v0.2.0
+    cnrm.cloud.google.com/deletion-policy: abandon
     cnrm.cloud.google.com/disable-dependent-services: "false"
     cnrm.cloud.google.com/project-id: my-project-id # kpt-set: ${project-id}
 spec:
@@ -33,7 +32,7 @@ metadata:
   name: 123456789012-pubsubsink # kpt-set: ${org-id}-pubsubsink
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/pubsub-export/v0.2.0
 spec:
   destination:
     pubSubTopicRef:
@@ -50,6 +49,6 @@ metadata:
   name: pubsub-logexport-dataset # kpt-set: ${topic-name}
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/pubsub-export/v0.2.0
 
 # TODO(jcwc): Add support for creating subscribers (either a new blueprint or kpt fn)

--- a/catalog/log-export/org/pubsub-export/iam.yaml
+++ b/catalog/log-export/org/pubsub-export/iam.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # IAM Policy Member
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -19,7 +18,7 @@ metadata:
   name: pubsub-iam-policy
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/pubsub-export/v0.2.0
 spec:
   memberFrom:
     logSinkRef:

--- a/catalog/log-export/org/storage-export/export.yaml
+++ b/catalog/log-export/org/storage-export/export.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # API Activation
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
@@ -19,8 +18,8 @@ metadata:
   name: my-project-id-storage # kpt-set: ${project-id}-storage
   namespace: projects
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/blueprint: cnrm/storage-export/v0.2.0
+    cnrm.cloud.google.com/deletion-policy: abandon
     cnrm.cloud.google.com/disable-dependent-services: "false"
     cnrm.cloud.google.com/project-id: my-project-id # kpt-set: ${project-id}
 spec:
@@ -33,7 +32,7 @@ metadata:
   name: 123456789012-storagesink # kpt-set: ${org-id}-storagesink
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/storage-export/v0.2.0
 spec:
   destination:
     storageBucketRef:
@@ -51,7 +50,7 @@ metadata:
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/force-destroy: "true"
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/storage-export/v0.2.0
 spec:
   bucketPolicyOnly: false # kpt-set: ${bucket-policy-only}
   location: US # kpt-set: ${location}

--- a/catalog/log-export/org/storage-export/iam.yaml
+++ b/catalog/log-export/org/storage-export/iam.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # IAM Policy Member
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -19,7 +18,7 @@ metadata:
   name: storage-project-iam-policy
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/storage-export/v0.2.0
 spec:
   memberFrom:
     logSinkRef:

--- a/catalog/networking/dns/managedzone-forwarding/dns.yaml
+++ b/catalog/networking/dns/managedzone-forwarding/dns.yaml
@@ -11,20 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSManagedZone
 metadata:
   name: dnsmanagedzone-sample # kpt-set: ${managed-zone-name}
   namespace: networking # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/dns-forwarding-managed-zone/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
-  dnsName: "example.com." # kpt-set: ${domain}
+  dnsName: example.com. # kpt-set: ${domain}
   forwardingConfig:
     targetNameServers:
-      - ipv4Address: "192.168.0.1" # kpt-set: ${forwarding-target-address}
+      - ipv4Address: 192.168.0.1 # kpt-set: ${forwarding-target-address}
   privateVisibilityConfig:
     networks:
       - networkRef:

--- a/catalog/networking/dns/managedzone-forwarding/services.yaml
+++ b/catalog/networking/dns/managedzone-forwarding/services.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   name: project-id-dns # kpt-set: ${project-id}-dns
   namespace: projects
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/dns-forwarding-managed-zone/v0.2.0
     cnrm.cloud.google.com/disable-on-destroy: "false"
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:

--- a/catalog/networking/dns/managedzone-peering/dns.yaml
+++ b/catalog/networking/dns/managedzone-peering/dns.yaml
@@ -11,17 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSManagedZone
 metadata:
   name: dnsmanagedzone-sample # kpt-set: ${managed-zone-name}
   namespace: networking # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/dns-peered-managed-zone/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
-  dnsName: "example.com." # kpt-set: ${domain}
+  dnsName: example.com. # kpt-set: ${domain}
   peeringConfig:
     targetNetwork:
       networkRef:

--- a/catalog/networking/dns/managedzone-peering/services.yaml
+++ b/catalog/networking/dns/managedzone-peering/services.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   name: project-id-dns # kpt-set: ${project-id}-dns
   namespace: projects
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/dns-peered-managed-zone/v0.2.0
     cnrm.cloud.google.com/disable-on-destroy: "false"
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:

--- a/catalog/networking/dns/managedzone-private/dns.yaml
+++ b/catalog/networking/dns/managedzone-private/dns.yaml
@@ -11,17 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSManagedZone
 metadata:
   name: dnsmanagedzone-sample # kpt-set: ${managed-zone-name}
   namespace: networking # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/dns-private-managed-zone/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
-  dnsName: "example.com." # kpt-set: ${domain}
+  dnsName: example.com. # kpt-set: ${domain}
   privateVisibilityConfig:
     networks:
       - networkRef:

--- a/catalog/networking/dns/managedzone-private/services.yaml
+++ b/catalog/networking/dns/managedzone-private/services.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   name: project-id-dns # kpt-set: ${project-id}-dns
   namespace: projects
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/dns-private-managed-zone/v0.2.0
     cnrm.cloud.google.com/disable-on-destroy: "false"
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:

--- a/catalog/networking/dns/policy/policy.yaml
+++ b/catalog/networking/dns/policy/policy.yaml
@@ -17,7 +17,7 @@ metadata:
   name: default-dns-policy # kpt-set: ${dns-policy-name}
   namespace: networking # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/dns-policy/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
   enableInboundForwarding: true

--- a/catalog/networking/dns/recordset/recordset.yaml
+++ b/catalog/networking/dns/recordset/recordset.yaml
@@ -11,21 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSRecordSet
 metadata:
   name: dnsrecordset-sample-a # kpt-set: ${record-set-name}
   namespace: networking # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/dns-record-set/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
-  name: "www.example.com." # kpt-set: ${name}${domain}
-  type: "A" # kpt-set: ${type}
+  name: www.example.com. # kpt-set: ${name}${domain}
+  type: A # kpt-set: ${type}
   managedZoneRef:
     name: dnsrecordset-dep-a # kpt-set: ${managed-zone-name}
     namespace: networking # kpt-set: ${namespace}
   rrdatas: # kpt-set: ${records}
-    - "0.0.0.0"
+    - 0.0.0.0
   ttl: 300 # kpt-set: ${ttl}

--- a/catalog/networking/firewall/common-rules/egress/allow-google-apis.yaml
+++ b/catalog/networking/firewall/common-rules/egress/allow-google-apis.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeFirewall
 metadata:
   name: network-name-fw-allow-google-apis # kpt-set: ${network-name}-fw-allow-google-apis
   namespace: firewalls-namespace # kpt-set: ${firewalls-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/firewall-common-rules/v0.2.0
 spec:
   priority: 65534
   allow:
@@ -26,7 +25,7 @@ spec:
         - "443"
       protocol: tcp
   destinationRanges: # kpt-set: ${google-api-cidr}
-    - "199.36.153.8/30"
+    - 199.36.153.8/30
   direction: EGRESS
   disabled: true # kpt-set: ${dont-allow-google-apis}
   enableLogging: false # kpt-set: ${enable-logging}

--- a/catalog/networking/firewall/common-rules/egress/allow-windows-kms.yaml
+++ b/catalog/networking/firewall/common-rules/egress/allow-windows-kms.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeFirewall
 metadata:
   name: network-name-fw-allow-windows-kms # kpt-set: ${network-name}-fw-allow-windows-kms
   namespace: firewalls-namespace # kpt-set: ${firewalls-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/firewall-common-rules/v0.2.0
 spec:
   priority: 100
   allow:
@@ -26,7 +25,7 @@ spec:
         - "1688"
       protocol: tcp
   destinationRanges:
-    - "35.190.247.13/32"
+    - 35.190.247.13/32
   direction: EGRESS
   disabled: true # kpt-set: ${dont-allow-windows-kms}
   enableLogging: false # kpt-set: ${enable-logging}

--- a/catalog/networking/firewall/common-rules/egress/deny-all.yaml
+++ b/catalog/networking/firewall/common-rules/egress/deny-all.yaml
@@ -11,21 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeFirewall
 metadata:
   name: network-name-fw-deny-all-egress # kpt-set: ${network-name}-fw-deny-all-egress
   namespace: firewalls-namespace # kpt-set: ${firewalls-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/firewall-common-rules/v0.2.0
 spec:
   priority: 65535
   deny:
     - protocol: tcp
     - protocol: udp
   destinationRanges:
-    - "0.0.0.0/0"
+    - 0.0.0.0/0
   direction: EGRESS
   disabled: true # kpt-set: ${allow-default-egress}
   enableLogging: false # kpt-set: ${enable-logging}

--- a/catalog/networking/firewall/common-rules/ingress/allow-gcp-lb.yaml
+++ b/catalog/networking/firewall/common-rules/ingress/allow-gcp-lb.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeFirewall
 metadata:
   name: network-name-fw-allow-gcp-lb # kpt-set: ${network-name}-fw-allow-gcp-lb
   namespace: firewalls-namespace # kpt-set: ${firewalls-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/firewall-common-rules/v0.2.0
 spec:
   priority: 10000 # kpt-set: ${priority}
   allow:
@@ -33,9 +32,9 @@ spec:
   networkRef:
     name: network-name # kpt-set: ${network-name}
   sourceRanges:
-    - "35.191.0.0/16"
-    - "130.211.0.0/22"
-    - "209.85.152.0/22"
-    - "209.85.204.0/22"
+    - 35.191.0.0/16
+    - 130.211.0.0/22
+    - 209.85.152.0/22
+    - 209.85.204.0/22
   targetTags:
     - allow-gcp-lb

--- a/catalog/networking/firewall/common-rules/ingress/allow-iap-rdp.yaml
+++ b/catalog/networking/firewall/common-rules/ingress/allow-iap-rdp.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeFirewall
 metadata:
   name: network-name-fw-allow-iap-rdp # kpt-set: ${network-name}-fw-allow-iap-rdp
   namespace: firewalls-namespace # kpt-set: ${firewalls-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/firewall-common-rules/v0.2.0
 spec:
   priority: 10000 # kpt-set: ${priority}
   allow:
@@ -31,6 +30,6 @@ spec:
   networkRef:
     name: network-name # kpt-set: ${network-name}
   sourceRanges:
-    - "35.235.240.0/20"
+    - 35.235.240.0/20
   targetTags:
     - allow-iap-rdp

--- a/catalog/networking/firewall/common-rules/ingress/allow-iap-ssh.yaml
+++ b/catalog/networking/firewall/common-rules/ingress/allow-iap-ssh.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeFirewall
 metadata:
   name: network-name-fw-allow-iap-ssh # kpt-set: ${network-name}-fw-allow-iap-ssh
   namespace: firewalls-namespace # kpt-set: ${firewalls-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/firewall-common-rules/v0.2.0
 spec:
   priority: 10000 # kpt-set: ${priority}
   allow:
@@ -31,6 +30,6 @@ spec:
   networkRef:
     name: network-name # kpt-set: ${network-name}
   sourceRanges:
-    - "35.235.240.0/20"
+    - 35.235.240.0/20
   targetTags:
     - allow-iap-ssh

--- a/catalog/networking/firewall/common-rules/ingress/allow-internal-common.yaml
+++ b/catalog/networking/firewall/common-rules/ingress/allow-internal-common.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeFirewall
 metadata:
   name: network-name-fw-allow-internal-common # kpt-set: ${network-name}-fw-allow-internal-common
   namespace: firewalls-namespace # kpt-set: ${firewalls-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/firewall-common-rules/v0.2.0
 spec:
   priority: 10000 # kpt-set: ${priority}
   allow:
@@ -34,8 +33,8 @@ spec:
   networkRef:
     name: network-name # kpt-set: ${network-name}
   sourceRanges:
-    - "10.0.0.0/8"
-    - "172.16.0.0/12"
-    - "192.168.0.0/16"
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
   targetTags:
     - allow-internal-common

--- a/catalog/networking/network/subnet/nat.yaml
+++ b/catalog/networking/network/subnet/nat.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeRouterNAT
 metadata:
@@ -19,7 +18,7 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network:subnetwork/v0.2.0
 spec:
   natIpAllocateOption: AUTO_ONLY
   region: us-central1 # kpt-set: ${region}
@@ -34,7 +33,7 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network:subnetwork/v0.2.0
 spec:
   description: example router description
   networkRef:

--- a/catalog/networking/network/subnet/subnet.yaml
+++ b/catalog/networking/network/subnet/subnet.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSubnetwork
 metadata:
@@ -19,7 +18,7 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network:subnetwork/v0.2.0
 spec:
   description: Subnetwork
   ipCidrRange: 10.2.0.0/16 # kpt-set: ${ip-cidr-range}

--- a/catalog/networking/network/vpc/services.yaml
+++ b/catalog/networking/network/vpc/services.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   name: project-id-compute # kpt-set: ${project-id}-compute
   namespace: projects
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network:vpc/v0.2.0
     cnrm.cloud.google.com/disable-on-destroy: "false"
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:

--- a/catalog/networking/network/vpc/vpc.yaml
+++ b/catalog/networking/network/vpc/vpc.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:
   name: network-name # kpt-set: ${network-name}
   namespace: networking # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network:vpc/v0.2.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
   autoCreateSubnetworks: false

--- a/catalog/networking/network/vpn.yaml
+++ b/catalog/networking/network/vpn.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeTargetVPNGateway
 metadata:
@@ -19,9 +18,9 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network/v0.2.0
 spec:
-  description: "Compute VPN Gateway"
+  description: Compute VPN Gateway
   networkRef:
     name: network-name # kpt-set: ${network-name}
   region: us-central1 # kpt-set: ${region}
@@ -33,11 +32,11 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network/v0.2.0
 spec:
   localTrafficSelector:
-    - "192.168.0.0/16"
-  peerIp: "15.0.0.120"
+    - 192.168.0.0/16
+  peerIp: 15.0.0.120
   region: us-central1 # kpt-set: ${region}
   sharedSecret:
     valueFrom:
@@ -54,9 +53,9 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network/v0.2.0
 spec:
-  description: "Regional address"
+  description: Regional address
   location: us-central1 # kpt-set: ${region}
 ---
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
@@ -66,13 +65,13 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network/v0.2.0
 spec:
-  description: "Regional ESP forwarding rule"
+  description: Regional ESP forwarding rule
   ipAddress:
     addressRef:
       name: network-name-vpn-address # kpt-set: ${network-name}-vpn-address
-  ipProtocol: "ESP"
+  ipProtocol: ESP
   location: us-central1 # kpt-set: ${region}
   target:
     targetVPNGatewayRef:
@@ -85,13 +84,13 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network/v0.2.0
 spec:
-  description: "Regional UDP 500 forwarding rule"
+  description: Regional UDP 500 forwarding rule
   ipAddress:
     addressRef:
       name: network-name-vpn-address # kpt-set: ${network-name}-vpn-address
-  ipProtocol: "UDP"
+  ipProtocol: UDP
   location: us-central1 # kpt-set: ${region}
   portRange: "500"
   target:
@@ -105,13 +104,13 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network/v0.2.0
 spec:
-  description: "Regional UDP 4500 forwarding rule"
+  description: Regional UDP 4500 forwarding rule
   ipAddress:
     addressRef:
       name: network-name-vpn-address # kpt-set: ${network-name}-vpn-address
-  ipProtocol: "UDP"
+  ipProtocol: UDP
   location: us-central1 # kpt-set: ${region}
   portRange: "4500"
   target:

--- a/catalog/networking/peering/peering.yaml
+++ b/catalog/networking/peering/peering.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetworkPeering
 metadata:
   name: local-network-to-peer-network # kpt-set: ${local-network}-to-${peer-network}
   namespace: namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network-peering/v0.2.0
 spec:
   exportCustomRoutes: false
   exportSubnetRoutesWithPublicIp: true
@@ -37,7 +36,7 @@ metadata:
   name: peer-network-to-local-network # kpt-set: ${peer-network}-to-${local-network}
   namespace: namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/network-peering/v0.2.0
 spec:
   exportCustomRoutes: false
   exportSubnetRoutesWithPublicIp: true

--- a/catalog/networking/routes/routes-igw/route.yaml
+++ b/catalog/networking/routes/routes-igw/route.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/compute-route-igw/v0.2.0
 spec:
   priority: 1000
   destRange: 0.0.0.0/0 # kpt-set: ${destination-range}

--- a/catalog/networking/shared-vpc/sharedVPC.yaml
+++ b/catalog/networking/shared-vpc/sharedVPC.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSharedVPCHostProject
 metadata:
@@ -19,4 +18,4 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/shared-vpc/v0.2.0

--- a/catalog/networking/svpc-service-project/serviceproject.yaml
+++ b/catalog/networking/svpc-service-project/serviceproject.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSharedVPCServiceProject
 metadata:
@@ -19,7 +18,7 @@ metadata:
   namespace: networking # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: host-project # kpt-set: ${host-project-id}
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/svpc-service-project/v0.2.0
 spec:
   projectRef:
     name: project-id # kpt-set: ${project-id}

--- a/catalog/networking/vpc-service-controls/access-policy/policy.yaml
+++ b/catalog/networking/vpc-service-controls/access-policy/policy.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: accesscontextmanager.cnrm.cloud.google.com/v1beta1
 kind: AccessContextManagerAccessPolicy
 metadata:
   name: org-access-policy # kpt-set: ${access-policy-name}
   namespace: networking # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/service-controls-access-policy/v0.2.0
     cnrm.cloud.google.com/organization-id: example-org # kpt-set: ${org-id}
 spec:
   title: org-access-policy Policy # kpt-set: ${access-policy-name} Policy

--- a/catalog/networking/vpc-service-controls/perimeter/access-level.yaml
+++ b/catalog/networking/vpc-service-controls/perimeter/access-level.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: accesscontextmanager.cnrm.cloud.google.com/v1beta1
 kind: AccessContextManagerAccessLevel
 metadata:
   name: alregionperimeter # kpt-set: al${perimeter-name}${suffix}
   namespace: networking # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/service-controls-perimeter/v0.2.0
     cnrm.cloud.google.com/organization-id: example-org # kpt-set: ${org-id}
 spec:
   accessPolicyRef:

--- a/catalog/networking/vpc-service-controls/perimeter/perimeter.yaml
+++ b/catalog/networking/vpc-service-controls/perimeter/perimeter.yaml
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: accesscontextmanager.cnrm.cloud.google.com/v1beta1
 kind: AccessContextManagerServicePerimeter
 metadata:
   name: spcregionperimeter # kpt-set: sp${perimeter-name}${suffix}
   namespace: networking # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/service-controls-perimeter/v0.2.0
 spec:
   status:
     resources:
@@ -28,8 +27,8 @@ spec:
     accessLevels:
       - name: alregionperimeter # kpt-set: al${perimeter-name}${suffix}
     restrictedServices: # kpt-set: ${restricted-services}
-      - "storage.googleapis.com"
-      - "bigquery.googleapis.com"
+      - storage.googleapis.com
+      - bigquery.googleapis.com
   accessPolicyRef:
     name: org-access-policy # kpt-set: ${access-policy-name}
     namespace: networking # kpt-set: ${namespace}

--- a/catalog/project/kcc-namespace/kcc-namespace-viewer.yaml
+++ b/catalog/project/kcc-namespace/kcc-namespace-viewer.yaml
@@ -18,6 +18,8 @@ kind: RoleBinding
 metadata:
   name: cnrm-network-viewer-project-id # kpt-set: cnrm-network-viewer-${project-id}
   namespace: networking # kpt-set: ${networking-namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/project:kcc-namespace/v0.2.0
 roleRef:
   name: cnrm-viewer
   kind: ClusterRole
@@ -34,6 +36,8 @@ kind: RoleBinding
 metadata:
   name: cnrm-project-viewer-project-id # kpt-set: cnrm-project-viewer-${project-id}
   namespace: projects # kpt-set: ${projects-namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/project:kcc-namespace/v0.2.0
 roleRef:
   name: cnrm-viewer
   kind: ClusterRole

--- a/catalog/project/kcc-namespace/kcc-project-owner.yaml
+++ b/catalog/project/kcc-namespace/kcc-project-owner.yaml
@@ -18,7 +18,7 @@ metadata:
   name: kcc-project-id-owners-permissions # kpt-set: kcc-${project-id}-owners-permissions
   namespace: projects # kpt-set: ${projects-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.2.0-alpha.1
+    cnrm.cloud.google.com/blueprint: cnrm/project:kcc-namespace/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:

--- a/catalog/project/kcc-namespace/kcc.yaml
+++ b/catalog/project/kcc-namespace/kcc.yaml
@@ -18,7 +18,7 @@ metadata:
   name: configconnectorcontext.core.cnrm.cloud.google.com
   namespace: project-id # kpt-set: ${project-id}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/project:kcc-namespace/v0.2.0
 spec:
   googleServiceAccount: kcc-project-id@management-project-id.iam.gserviceaccount.com # kpt-set: kcc-${project-id}@${management-project-id}.iam.gserviceaccount.com
 ---
@@ -29,7 +29,7 @@ metadata:
   name: kcc-project-id # kpt-set: kcc-${project-id}
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/project:kcc-namespace/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   displayName: kcc-project-id # kpt-set: kcc-${project-id}
@@ -41,7 +41,7 @@ metadata:
   name: project-id-sa-workload-identity-binding # kpt-set: ${project-id}-sa-workload-identity-binding
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/project:kcc-namespace/v0.2.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:

--- a/catalog/project/kcc-namespace/namespace.yaml
+++ b/catalog/project/kcc-namespace/namespace.yaml
@@ -18,3 +18,4 @@ metadata:
   name: project-id # kpt-set: ${project-id}
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    cnrm.cloud.google.com/blueprint: cnrm/project:kcc-namespace/v0.2.0

--- a/catalog/project/project.yaml
+++ b/catalog/project/project.yaml
@@ -18,11 +18,11 @@ metadata:
   namespace: projects # kpt-set: ${projects-namespace}
   annotations:
     cnrm.cloud.google.com/auto-create-network: "false"
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:project/v0.2.0
+    cnrm.cloud.google.com/blueprint: cnrm/project/v0.2.0
 spec:
   name: project-id # kpt-set: ${project-id}
   billingAccountRef:
-    external: "AAAAAA-BBBBBB-CCCCCC" # kpt-set: ${billing-account-id}
+    external: AAAAAA-BBBBBB-CCCCCC # kpt-set: ${billing-account-id}
   folderRef:
     name: name.of.folder # kpt-set: ${folder-name}
     namespace: hierarchy # kpt-set: ${folder-namespace}

--- a/catalog/redis-bucket/bucket.yaml
+++ b/catalog/redis-bucket/bucket.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: storage.cnrm.cloud.google.com/v1beta1
 kind: StorageBucket
 metadata:
@@ -20,6 +19,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/force-destroy: "false"
     cnrm.cloud.google.com/project-id: blueprints-project # kpt-set: ${project-id}
+    cnrm.cloud.google.com/blueprint: cnrm/redis-bucket/v0.2.0
 spec:
   storageClass: standard # kpt-set: ${storage-class}
   uniformBucketLevelAccess: true

--- a/catalog/redis-bucket/redis.yaml
+++ b/catalog/redis-bucket/redis.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
@@ -20,6 +19,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/disable-on-destroy: "false"
     cnrm.cloud.google.com/project-id: blueprints-project # kpt-set: ${project-id}
+    cnrm.cloud.google.com/blueprint: cnrm/redis-bucket/v0.2.0
 spec:
   resourceID: redis.googleapis.com
 ---
@@ -30,6 +30,7 @@ metadata:
   namespace: config-controller-system # kpt-set: ${namespace}
   annotations:
     cnrm.cloud.google.com/project-id: blueprints-project # kpt-set: ${project-id}
+    cnrm.cloud.google.com/blueprint: cnrm/redis-bucket/v0.2.0
 spec:
   authorizedNetworkRef:
     external: projects/blueprints-project/global/networks/default # kpt-set: projects/${project-id}/global/networks/${network}

--- a/catalog/spanner/policies/deletion-policy-required-constraint.yaml
+++ b/catalog/spanner/policies/deletion-policy-required-constraint.yaml
@@ -11,15 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GCPRequireDeletionPolicy
 metadata:
   name: enforce-deletion-policy-annotation-spanner-instance
   annotations:
     description: Checks that resource has deletion-policy annotation set.
+    cnrm.cloud.google.com/blueprint: cnrm/spanner/v0.2.0
 spec:
   match:
     kinds:
-      - apiGroups: ["spanner.cnrm.cloud.google.com"]
-        kinds: ["SpannerInstance", "SpannerDatabase"]
+      - apiGroups:
+          - spanner.cnrm.cloud.google.com
+        kinds:
+          - SpannerInstance
+          - SpannerDatabase

--- a/catalog/spanner/spanner.yaml
+++ b/catalog/spanner/spanner.yaml
@@ -11,17 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: spanner.cnrm.cloud.google.com/v1beta1
 kind: SpannerDatabase
 metadata:
   name: spanner-sample-database # kpt-set: ${database-name}
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/deletion-policy: abandon
+    cnrm.cloud.google.com/blueprint: cnrm/spanner/v0.2.0
 spec:
   ddl:
-    - "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)"
+    - CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)
   instanceRef:
     name: spanner-sample-instance # kpt-set: ${instance-name}
 ---
@@ -31,8 +31,9 @@ metadata:
   name: spanner-sample-instance # kpt-set: ${instance-name}
   namespace: my-namespace # kpt-set: ${namespace}
   annotations:
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/deletion-policy: abandon
+    cnrm.cloud.google.com/blueprint: cnrm/spanner/v0.2.0
 spec:
   config: regional-us-central1 # kpt-set: ${config-region}
-  displayName: "spanner-sample-instance" # kpt-set: ${instance-name}
+  displayName: spanner-sample-instance # kpt-set: ${instance-name}
   numNodes: 1 # kpt-set: ${num-nodes}

--- a/utils/add-attribution.sh
+++ b/utils/add-attribution.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,41 @@
 set -o errexit -o nounset -o pipefail
 
 PKG_PATH="${1:-.}"
-BLUEPRINT_NAME="${BLUEPRINT_NAME:-$(grep -m 1 "name:" "${PKG_PATH}/Kptfile" | sed 's/[[:space:]]*name:[[:space:]]*//')}"
-BLUEPRINT_VERSION="${BLUEPRINT_VERSION:-$(cd "${PKG_PATH}" && git describe --abbrev=0)}"
 
-kpt fn source "${PKG_PATH}" |
-    kpt cfg grep "apiVersion=cnrm" |
-    kpt fn run --image gcr.io/kpt-fn/set-annotation:v0.1 -- "cnrm.cloud.google.com/blueprint=cnrm/${BLUEPRINT_NAME}/${BLUEPRINT_VERSION}" |
-    kpt fn sink "${PKG_PATH}"
+CATALOG_PATH="catalog"
+BLUEPRINT_TOOL="cnrm"
+BLUEPRINT_ANNOTATION="cnrm.cloud.google.com/blueprint"
+
+KPT_VERSION="$(kpt version)"
+if [[ "${KPT_VERSION}" != "1."* || "${KPT_VERSION}" == "1.0.0-beta.1" || "${KPT_VERSION}" == "1.0.0-alpha"* ]]; then
+    echo >&2 "Error: requires kpt verion of at least 1.0.0-beta.2"
+    exit 2
+fi
+
+function print_catalog_path() {
+    local path="${1}"
+    if [[ ! -f "${path}/Kptfile" ]]; then
+        echo >&2 "Error: no Kptfile in package path: ${path}"
+        return 2
+    fi
+    local full_path="$(cd "${path}" && pwd -P)"
+    local repo_root="$(cd "${full_path}" && git rev-parse --show-toplevel)"
+    local prefix="${repo_root}/${CATALOG_PATH}/"
+    if [[ "${full_path}" != "${prefix}"* ]]; then
+        echo >&2 "Error: package not in catalog: ${path}"
+        return 2
+    fi
+    local relative_path="${full_path#"${prefix}"}"
+    echo "${relative_path}"
+}
+
+function print_repo_version() {
+    local path="${1}"
+    echo "$(cd "${path}" && git describe --abbrev=0)"
+}
+
+BLUEPRINT_NAME="${BLUEPRINT_NAME:-$(print_catalog_path "${PKG_PATH}")}"
+BLUEPRINT_VERSION="${BLUEPRINT_VERSION:-$(print_repo_version "${PKG_PATH}")}"
+BLUEPRINT_ATTRIBTUION="${BLUEPRINT_TOOL}/${BLUEPRINT_NAME}/${BLUEPRINT_VERSION}"
+
+kpt fn eval "${PKG_PATH}" --image gcr.io/kpt-fn/set-annotation:v0.1 -- "${BLUEPRINT_ANNOTATION}=${BLUEPRINT_ATTRIBTUION}"

--- a/utils/fix-attribution.sh
+++ b/utils/fix-attribution.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+COLOR_RED='\033[0;31m'
+COLOR_NONE='\033[0m'
+
+if ! hash jq 2>/dev/null; then
+    echo >&2 "Error: jq not found. Please install jq: https://stedolan.github.io/jq/download/"
+fi
+
+if ! hash yq 2>/dev/null; then
+    echo >&2 "Error: yq not found. Please install yq: https://pypi.org/project/yq/"
+fi
+
+function kptfile_pkg_name() {
+    local path="${1}"
+    local name=""
+    if [[ -f "${path}/Kptfile" ]]; then
+        name="$(yq -er '.metadata.name' "${path}/Kptfile")"
+    fi
+    if [[ -z "${name}" || "${name}" == "null" ]]; then
+        name="$(basename "${path}")"
+    fi
+    echo "${name}"
+}
+
+function handle_dir() {
+    local parent_path="${1}"
+    local parent_name="${2:-}"
+    for child_path in "${parent_path}"/*; do
+        local child_name=""
+        if [[ -d "${child_path}" ]]; then
+            # Attribute parents before children so that package names are as specific as possible
+            if [[ -f "${child_path}/Kptfile" ]]; then
+                child_name="$(kptfile_pkg_name "${child_path}")"
+
+                # build attribution name by concatonating parent package names with colon delimiters
+                if [[ -n "${parent_name}" ]]; then
+                    child_name="${parent_name}:${child_name}"
+                fi
+                
+                echo -en "Processing:\t"
+                echo -n "${child_path}"
+                echo -en "\t"
+                echo "(name: ${child_name})"
+                BLUEPRINT_NAME="${child_name}" utils/add-attribution.sh "${child_path}"
+            fi
+            handle_dir "${child_path}" "${child_name:-${parent_name:-}}"
+        fi
+    done
+}
+
+handle_dir "catalog"


### PR DESCRIPTION
- Update add-attribution.sh for kpt v1.0.0-beta.2

Limitations:
1.  Requires at least kpt v1.0.0-beta.2
1.  kpt randomly deletes some files for unknown reason:
    ```
    deleted:    catalog/empty/noop.yaml
    deleted:    catalog/hierarchy/bu/hierarchy.yaml
    deleted:    catalog/hierarchy/env-bu/hierarchy.yaml
    deleted:    catalog/hierarchy/simple/hierarchy.yaml
    deleted:    catalog/hierarchy/team/hierarchy.yaml
    ```
1.  `kpt fn grep` was removed and there's no replacement to only edit certain files with functions.
1.  `kpt fn sink` doesn't support updating existing directories, so I had to use `kpt fn eval` instead

Replaces https://github.com/GoogleCloudPlatform/blueprints/pull/36