### PR TITLE
Update add-attribribution and add fix-attribution.sh

### DIFF
--- a/utils/add-attribution.sh
+++ b/utils/add-attribution.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,41 @@
 set -o errexit -o nounset -o pipefail
 
 PKG_PATH="${1:-.}"
-BLUEPRINT_NAME="${BLUEPRINT_NAME:-$(grep -m 1 "name:" "${PKG_PATH}/Kptfile" | sed 's/[[:space:]]*name:[[:space:]]*//')}"
-BLUEPRINT_VERSION="${BLUEPRINT_VERSION:-$(cd "${PKG_PATH}" && git describe --abbrev=0)}"
 
-kpt fn source "${PKG_PATH}" |
-    kpt cfg grep "apiVersion=cnrm" |
-    kpt fn run --image gcr.io/kpt-fn/set-annotation:v0.1 -- "cnrm.cloud.google.com/blueprint=cnrm/${BLUEPRINT_NAME}/${BLUEPRINT_VERSION}" |
-    kpt fn sink "${PKG_PATH}"
+CATALOG_PATH="catalog"
+BLUEPRINT_TOOL="cnrm"
+BLUEPRINT_ANNOTATION="cnrm.cloud.google.com/blueprint"
+
+KPT_VERSION="$(kpt version)"
+if [[ "${KPT_VERSION}" != "1."* || "${KPT_VERSION}" == "1.0.0-beta.1" || "${KPT_VERSION}" == "1.0.0-alpha"* ]]; then
+    echo >&2 "Error: requires kpt verion of at least 1.0.0-beta.2"
+    exit 2
+fi
+
+function print_catalog_path() {
+    local path="${1}"
+    if [[ ! -f "${path}/Kptfile" ]]; then
+        echo >&2 "Error: no Kptfile in package path: ${path}"
+        return 2
+    fi
+    local full_path="$(cd "${path}" && pwd -P)"
+    local repo_root="$(cd "${full_path}" && git rev-parse --show-toplevel)"
+    local prefix="${repo_root}/${CATALOG_PATH}/"
+    if [[ "${full_path}" != "${prefix}"* ]]; then
+        echo >&2 "Error: package not in catalog: ${path}"
+        return 2
+    fi
+    local relative_path="${full_path#"${prefix}"}"
+    echo "${relative_path}"
+}
+
+function print_repo_version() {
+    local path="${1}"
+    echo "$(cd "${path}" && git describe --abbrev=0)"
+}
+
+BLUEPRINT_NAME="${BLUEPRINT_NAME:-$(print_catalog_path "${PKG_PATH}")}"
+BLUEPRINT_VERSION="${BLUEPRINT_VERSION:-$(print_repo_version "${PKG_PATH}")}"
+BLUEPRINT_ATTRIBTUION="${BLUEPRINT_TOOL}/${BLUEPRINT_NAME}/${BLUEPRINT_VERSION}"
+
+kpt fn eval "${PKG_PATH}" --image gcr.io/kpt-fn/set-annotations:v0.1 -- "${BLUEPRINT_ANNOTATION}=${BLUEPRINT_ATTRIBTUION}"

--- a/utils/fix-attribution.sh
+++ b/utils/fix-attribution.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+COLOR_RED='\033[0;31m'
+COLOR_NONE='\033[0m'
+
+if ! hash jq 2>/dev/null; then
+    echo >&2 "Error: jq not found. Please install jq: https://stedolan.github.io/jq/download/"
+fi
+
+if ! hash yq 2>/dev/null; then
+    echo >&2 "Error: yq not found. Please install yq: https://pypi.org/project/yq/"
+fi
+
+function kptfile_pkg_name() {
+    local path="${1}"
+    local name=""
+    if [[ -f "${path}/Kptfile" ]]; then
+        name="$(yq -er '.metadata.name' "${path}/Kptfile")"
+    fi
+    if [[ -z "${name}" || "${name}" == "null" ]]; then
+        name="$(basename "${path}")"
+    fi
+    echo "${name}"
+}
+
+function handle_dir() {
+    local parent_path="${1}"
+    local parent_name="${2:-}"
+    for child_path in "${parent_path}"/*; do
+        local child_name=""
+        if [[ -d "${child_path}" ]]; then
+            # Attribute parents before children so that package names are as specific as possible
+            if [[ -f "${child_path}/Kptfile" ]]; then
+                child_name="$(kptfile_pkg_name "${child_path}")"
+
+                # build attribution name by concatonating parent package names with colon delimiters
+                if [[ -n "${parent_name}" ]]; then
+                    child_name="${parent_name}:${child_name}"
+                fi
+                
+                echo -en "Processing:\t"
+                echo -n "${child_path}"
+                echo -en "\t"
+                echo "(name: ${child_name})"
+                BLUEPRINT_NAME="${child_name}" utils/add-attribution.sh "${child_path}"
+            fi
+            handle_dir "${child_path}" "${child_name:-${parent_name:-}}"
+        fi
+    done
+}
+
+handle_dir "catalog"


### PR DESCRIPTION
Limitations:
1. Requires at least kpt v1.0.0-beta.2
1. kpt fn grep was removed and there's no replacement to only edit certain files with functions.
1. kpt fn sink doesn't support updating existing directories, so I had to use kpt fn eval instead
1. kpt drops single quotes around strings: https://github.com/GoogleContainerTools/kpt/issues/2383

Replaces https://github.com/GoogleCloudPlatform/blueprints/pull/54