### PR TITLE
fix: gitops hydration trigger

### DIFF
--- a/catalog/gitops/hydration-trigger.yaml
+++ b/catalog/gitops/hydration-trigger.yaml
@@ -75,7 +75,7 @@ spec:
           - |
             set -e
             git pull origin $BRANCH_NAME || true # Ignore errors in case branch doesn't exist
-            git rm -rf /deployment-workspace/config/*
+            git rm -rf /deployment-workspace/config/* --ignore-unmatch
             cp -r /hydrated-workspace/config /deployment-workspace/
             touch /deployment-workspace/config/.gitkeep
             # Configure Git to create commits with Cloud Build's service account


### PR DESCRIPTION
For the initial build, `config/*` may not match any files leading to `fatal: pathspec '/deployment-workspace/config/*' did not match any files`. This adds ` --ignore-unmatch` flag so exit code will still be zero.