### PR TITLE
Switch to using IAMPartialPolicy instead of IAMPolicyMember

### DIFF
--- a/catalog/gitops/README.md
+++ b/catalog/gitops/README.md
@@ -34,8 +34,8 @@ source-repo      5
 
 ```
 File                      APIVersion                                  Kind                  Name                              Namespace
-cloudbuild-iam.yaml       iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember       deployment-repo-cloudbuild-write  config-control
-cloudbuild-iam.yaml       iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember       source-repo-cloudbuild-read       config-control
+cloudbuild-iam.yaml       iam.cnrm.cloud.google.com/v1beta1           IAMPartialPolicy       deployment-repo-cloudbuild-write  config-control
+cloudbuild-iam.yaml       iam.cnrm.cloud.google.com/v1beta1           IAMPartialPolicy       source-repo-cloudbuild-read       config-control
 hydration-trigger.yaml    cloudbuild.cnrm.cloud.google.com/v1beta1    CloudBuildTrigger     source-repo-cicd-trigger          config-control
 services.yaml             serviceusage.cnrm.cloud.google.com/v1beta1  Service               cloudbuild.googleapis.com         config-control
 services.yaml             serviceusage.cnrm.cloud.google.com/v1beta1  Service               sourcerepo.googleapis.com         config-control
@@ -46,7 +46,7 @@ source-repositories.yaml  sourcerepo.cnrm.cloud.google.com/v1beta1    SourceRepo
 ## Resource References
 
 - [CloudBuildTrigger](https://cloud.google.com/config-connector/docs/reference/resource-docs/cloudbuild/cloudbuildtrigger)
-- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
 - [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
 - [SourceRepoRepository](https://cloud.google.com/config-connector/docs/reference/resource-docs/sourcerepo/sourcereporepository)
 
@@ -88,4 +88,3 @@ source-repositories.yaml  sourcerepo.cnrm.cloud.google.com/v1beta1    SourceRepo
     ```
     kpt live status --output table --poll-until current
     ```
-

--- a/catalog/gitops/cloudbuild-iam.yaml
+++ b/catalog/gitops/cloudbuild-iam.yaml
@@ -27,8 +27,8 @@ spec:
     kind: SourceRepoRepository
   bindings:
     - role: roles/source.writer
-    members:
-      - member: serviceAccount:1234567890123@cloudbuild.gserviceaccount.com # kpt-set: serviceAccount:${project-number}@cloudbuild.gserviceaccount.com
+      members:
+        - member: serviceAccount:1234567890123@cloudbuild.gserviceaccount.com # kpt-set: serviceAccount:${project-number}@cloudbuild.gserviceaccount.com
 ---
 # Provides read access to source repo for cloudbuild trigger
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
@@ -46,5 +46,5 @@ spec:
     kind: SourceRepoRepository
   bindings:
     - role: roles/source.reader
-    members:
-      - member: serviceAccount:1234567890123@cloudbuild.gserviceaccount.com # kpt-set: serviceAccount:${project-number}@cloudbuild.gserviceaccount.com
+      members:
+        - member: serviceAccount:1234567890123@cloudbuild.gserviceaccount.com # kpt-set: serviceAccount:${project-number}@cloudbuild.gserviceaccount.com

--- a/catalog/gitops/cloudbuild-iam.yaml
+++ b/catalog/gitops/cloudbuild-iam.yaml
@@ -26,7 +26,7 @@ spec:
     apiVersion: sourcerepo.cnrm.cloud.google.com/v1beta1
     kind: SourceRepoRepository
   bindings:
-    - role: role: roles/source.writer
+    - role: roles/source.writer
     members:
       - member: serviceAccount:1234567890123@cloudbuild.gserviceaccount.com # kpt-set: serviceAccount:${project-number}@cloudbuild.gserviceaccount.com
 ---

--- a/catalog/gitops/cloudbuild-iam.yaml
+++ b/catalog/gitops/cloudbuild-iam.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # Provides write access to deployment repo for cloudbuild trigger
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: deployment-repo-cloudbuild-write
   namespace: config-control # kpt-set: ${namespace}
@@ -21,16 +21,18 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/gitops/v0.3.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
-  member: serviceAccount:1234567890123@cloudbuild.gserviceaccount.com # kpt-set: serviceAccount:${project-number}@cloudbuild.gserviceaccount.com
   resourceRef:
     name: deployment-repo # kpt-set: ${deployment-repo}
     apiVersion: sourcerepo.cnrm.cloud.google.com/v1beta1
     kind: SourceRepoRepository
-  role: roles/source.writer
+  bindings:
+    - role: role: roles/source.writer
+    members:
+      - member: serviceAccount:1234567890123@cloudbuild.gserviceaccount.com # kpt-set: serviceAccount:${project-number}@cloudbuild.gserviceaccount.com
 ---
 # Provides read access to source repo for cloudbuild trigger
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: source-repo-cloudbuild-read
   namespace: config-control # kpt-set: ${namespace}
@@ -38,9 +40,11 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/gitops/v0.3.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
-  member: serviceAccount:1234567890123@cloudbuild.gserviceaccount.com # kpt-set: serviceAccount:${project-number}@cloudbuild.gserviceaccount.com
   resourceRef:
     name: source-repo # kpt-set: ${source-repo}
     apiVersion: sourcerepo.cnrm.cloud.google.com/v1beta1
     kind: SourceRepoRepository
-  role: roles/source.reader
+  bindings:
+    - role: roles/source.reader
+    members:
+      - member: serviceAccount:1234567890123@cloudbuild.gserviceaccount.com # kpt-set: serviceAccount:${project-number}@cloudbuild.gserviceaccount.com

--- a/catalog/gitops/configsync/README.md
+++ b/catalog/gitops/configsync/README.md
@@ -30,15 +30,15 @@ This package has no sub-packages.
 ```
 File                    APIVersion                         Kind               Name                                        Namespace
 config-management.yaml  configmanagement.gke.io/v1         ConfigManagement   config-management
-configsync-iam.yaml     iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember    source-reader-sync-cluster-name-project-id  config-control
-configsync-iam.yaml     iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember    sync-cluster-name                           config-control
+configsync-iam.yaml     iam.cnrm.cloud.google.com/v1beta1  IAMPartialPolicy    source-reader-sync-cluster-name-project-id  config-control
+configsync-iam.yaml     iam.cnrm.cloud.google.com/v1beta1  IAMPartialPolicy    sync-cluster-name                           config-control
 configsync-iam.yaml     iam.cnrm.cloud.google.com/v1beta1  IAMServiceAccount  sync-cluster-name                           config-control
 ```
 
 ## Resource References
 
 - [ConfigManagement](https://cloud.google.com/anthos-config-management/docs/configmanagement-fields)
-- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
 - [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)
 
 ## Usage
@@ -79,4 +79,3 @@ configsync-iam.yaml     iam.cnrm.cloud.google.com/v1beta1  IAMServiceAccount  sy
     ```
     kpt live status --output table --poll-until current
     ```
-

--- a/catalog/gitops/configsync/configsync-iam.yaml
+++ b/catalog/gitops/configsync/configsync-iam.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Config Sync GCP ServiceAccount (GSA)
-# This GSA can be used to grant Config Sync additional permissions with IAMPolicyMember
+# This GSA can be used to grant Config Sync additional permissions with IAMPartialPolicy
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
@@ -26,7 +26,7 @@ spec:
 ---
 # Allow Config Sync Kubernetes ServiceAccount (KSA) to use the Config Sync GSA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: sync-cluster-name # kpt-set: sync-${cluster-name}
   namespace: config-control # kpt-set: ${namespace}
@@ -34,16 +34,18 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/gitops/configsync/v0.3.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
-  member: serviceAccount:project-id.svc.id.goog[config-management-system/importer] # kpt-set: serviceAccount:${project-id}.svc.id.goog[config-management-system/importer]
   resourceRef:
     name: sync-cluster-name # kpt-set: sync-${cluster-name}
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
-  role: roles/iam.workloadIdentityUser
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:project-id.svc.id.goog[config-management-system/importer] # kpt-set: serviceAccount:${project-id}.svc.id.goog[config-management-system/importer]
 ---
 # Allow Config Sync GSA to read from CSR repos in the CSR project
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: source-reader-sync-cluster-name-project-id # kpt-set: source-reader-sync-${cluster-name}-${project-id}
   namespace: config-control # kpt-set: ${namespace}
@@ -51,9 +53,12 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/gitops/configsync/v0.3.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
-  member: serviceAccount:sync-cluster-name@project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:sync-${cluster-name}@${project-id}.iam.gserviceaccount.com
+  member:
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
     external: project-id # kpt-set: ${project-id}
-  role: roles/source.reader
+  bindings:
+    - role: roles/source.reader
+      members:
+        - member: serviceAccount:sync-cluster-name@project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:sync-${cluster-name}@${project-id}.iam.gserviceaccount.com

--- a/catalog/landing-zone/README.md
+++ b/catalog/landing-zone/README.md
@@ -27,43 +27,43 @@ This package has no sub-packages.
 
 ```
 File                                             APIVersion                                     Kind                    Name                                               Namespace
-iam.yaml                                         iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         billing-admins-iam                                 config-control
-iam.yaml                                         iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         org-admins-iam                                     config-control
+iam.yaml                                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         billing-admins-iam                                 config-control
+iam.yaml                                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         org-admins-iam                                     config-control
 namespaces/hierarchy.yaml                        core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  hierarchy
-namespaces/hierarchy.yaml                        iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         hierarchy-sa-folderadmin-permissions               config-control
-namespaces/hierarchy.yaml                        iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         hierarchy-sa-workload-identity-binding             config-control
+namespaces/hierarchy.yaml                        iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         hierarchy-sa-folderadmin-permissions               config-control
+namespaces/hierarchy.yaml                        iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         hierarchy-sa-workload-identity-binding             config-control
 namespaces/hierarchy.yaml                        iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       hierarchy-sa                                       config-control
 namespaces/hierarchy.yaml                        rbac.authorization.k8s.io/v1                   RoleBinding             allow-resource-reference-from-hierarchy            hierarchy
 namespaces/hierarchy.yaml                        v1                                             Namespace               hierarchy
 namespaces/logging.yaml                          core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  logging
-namespaces/logging.yaml                          iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         logging-sa-bigqueryadmin-permissions               config-control
-namespaces/logging.yaml                          iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         logging-sa-logadmin-permissions                    config-control
-namespaces/logging.yaml                          iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         logging-sa-workload-identity-binding               config-control
+namespaces/logging.yaml                          iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         logging-sa-bigqueryadmin-permissions               config-control
+namespaces/logging.yaml                          iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         logging-sa-logadmin-permissions                    config-control
+namespaces/logging.yaml                          iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         logging-sa-workload-identity-binding               config-control
 namespaces/logging.yaml                          iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       logging-sa                                         config-control
 namespaces/logging.yaml                          rbac.authorization.k8s.io/v1                   RoleBinding             allow-resource-reference-from-logging              projects
 namespaces/logging.yaml                          v1                                             Namespace               logging
 namespaces/networking.yaml                       core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  networking
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         networking-sa-dns-permissions                      config-control
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         networking-sa-networkadmin-permissions             config-control
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         networking-sa-security-permissions                 config-control
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         networking-sa-service-control-permissions          config-control
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         networking-sa-workload-identity-binding            config-control
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         networking-sa-xpnadmin-permissions                 config-control
+namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-dns-permissions                      config-control
+namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-networkadmin-permissions             config-control
+namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-security-permissions                 config-control
+namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-service-control-permissions          config-control
+namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-workload-identity-binding            config-control
+namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-xpnadmin-permissions                 config-control
 namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       networking-sa                                      config-control
 namespaces/networking.yaml                       rbac.authorization.k8s.io/v1                   RoleBinding             allow-resource-reference-from-networking           projects
 namespaces/networking.yaml                       v1                                             Namespace               networking
 namespaces/policies.yaml                         core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  policies
-namespaces/policies.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         policies-sa-orgpolicyadmin-permissions             config-control
-namespaces/policies.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         policies-sa-workload-identity-binding              config-control
+namespaces/policies.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         policies-sa-orgpolicyadmin-permissions             config-control
+namespaces/policies.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         policies-sa-workload-identity-binding              config-control
 namespaces/policies.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       policies-sa                                        config-control
 namespaces/policies.yaml                         v1                                             Namespace               policies
 namespaces/projects.yaml                         core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  projects
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         projects-sa-billinguser-permissions                config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         projects-sa-projectcreator-permissions             config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         projects-sa-projectdeleter-permissions             config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         projects-sa-projectmover-permissions               config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         projects-sa-serviceusageadmin-permissions          config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPolicyMember         projects-sa-workload-identity-binding              config-control
+namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-billinguser-permissions                config-control
+namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-projectcreator-permissions             config-control
+namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-projectdeleter-permissions             config-control
+namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-projectmover-permissions               config-control
+namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-serviceusageadmin-permissions          config-control
+namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-workload-identity-binding              config-control
 namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       projects-sa                                        config-control
 namespaces/projects.yaml                         v1                                             Namespace               projects
 policies/deletion-policy-required-template.yaml  templates.gatekeeper.sh/v1beta1                ConstraintTemplate      gcprequiredeletionpolicy
@@ -84,7 +84,7 @@ services.yaml                                    serviceusage.cnrm.cloud.google.
 
 - [ConfigConnectorContext](https://cloud.google.com/config-connector/docs/how-to/advanced-install#addon-configuring)
 - ConstraintTemplate
-- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
 - [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)
 - [Namespace](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#namespace-v1-core)
 - [ResourceManagerPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/resourcemanagerpolicy)
@@ -129,4 +129,3 @@ services.yaml                                    serviceusage.cnrm.cloud.google.
     ```
     kpt live status --output table --poll-until current
     ```
-

--- a/catalog/landing-zone/iam.yaml
+++ b/catalog/landing-zone/iam.yaml
@@ -13,31 +13,35 @@
 # limitations under the License.
 
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: org-admins-iam
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
 spec:
-  member: group:gcp-organization-admins@example.com # kpt-set: group:${group-org-admins}
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/resourcemanager.organizationAdmin
+  bindings:
+    - role: roles/resourcemanager.organizationAdmin
+      members:
+        - member: group:gcp-organization-admins@example.com # kpt-set: group:${group-org-admins}
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: billing-admins-iam
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
 spec:
-  member: group:gcp-billing-admins@example.com # kpt-set: group:${group-billing-admins}
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/billing.admin
+  bindings:
+    - role: roles/billing.admin
+      members:
+        - member: group:gcp-billing-admins@example.com # kpt-set: group:${group-billing-admins}

--- a/catalog/landing-zone/namespaces/hierarchy.yaml
+++ b/catalog/landing-zone/namespaces/hierarchy.yaml
@@ -23,7 +23,7 @@ spec:
   displayName: hierarchy-sa
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: hierarchy-sa-folderadmin-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -31,15 +31,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:hierarchy-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:hierarchy-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/resourcemanager.folderAdmin
+  bindings:
+    - role: roles/resourcemanager.folderAdmin
+      members:
+        - member: "serviceAccount:hierarchy-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:hierarchy-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: hierarchy-sa-workload-identity-binding
   namespace: config-control # kpt-set: ${management-namespace}
@@ -47,12 +49,14 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-hierarchy] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-hierarchy]
   resourceRef:
     name: hierarchy-sa
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
-  role: roles/iam.workloadIdentityUser
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-hierarchy] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-hierarchy]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/catalog/landing-zone/namespaces/logging.yaml
+++ b/catalog/landing-zone/namespaces/logging.yaml
@@ -41,7 +41,7 @@ spec:
   displayName: logging-sa
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: logging-sa-logadmin-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -49,15 +49,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/logging.admin
+  bindings:
+    - role: roles/logging.admin
+      members:
+        - member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: logging-sa-bigqueryadmin-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -65,15 +67,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/bigquery.admin
+  bindings:
+    - role: roles/bigquery.admin
+      members:
+        - member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: logging-sa-workload-identity-binding
   namespace: config-control # kpt-set: ${management-namespace}
@@ -81,12 +85,14 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-logging] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-logging]
   resourceRef:
     name: logging-sa
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
-  role: roles/iam.workloadIdentityUser
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-logging] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-logging]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/catalog/landing-zone/namespaces/networking.yaml
+++ b/catalog/landing-zone/namespaces/networking.yaml
@@ -24,7 +24,7 @@ spec:
   displayName: networking-sa
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: networking-sa-networkadmin-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -32,15 +32,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/compute.networkAdmin
+  bindings:
+    - role: roles/compute.networkAdmin
+      members:
+        - member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: networking-sa-security-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -48,15 +50,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/compute.securityAdmin
+  bindings:
+    - role: roles/compute.securityAdmin
+      members:
+        - member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: networking-sa-dns-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -64,15 +68,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/dns.admin
+  bindings:
+    - role: roles/dns.admin
+      members:
+        - member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: networking-sa-service-control-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -80,15 +86,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/accesscontextmanager.policyAdmin
+  bindings:
+    - role: roles/accesscontextmanager.policyAdmin
+      members:
+        - member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: networking-sa-xpnadmin-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -96,15 +104,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/compute.xpnAdmin
+  bindings:
+    - role: roles/compute.xpnAdmin
+      members:
+        - member: "serviceAccount:networking-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:networking-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: networking-sa-workload-identity-binding
   namespace: config-control # kpt-set: ${management-namespace}
@@ -112,12 +122,14 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-networking] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-networking]
   resourceRef:
     name: networking-sa
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
-  role: roles/iam.workloadIdentityUser
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member:serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-networking] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-networking]
 ---
 apiVersion: v1
 kind: Namespace

--- a/catalog/landing-zone/namespaces/policies.yaml
+++ b/catalog/landing-zone/namespaces/policies.yaml
@@ -24,7 +24,7 @@ spec:
   displayName: policies-sa
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: policies-sa-orgpolicyadmin-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -32,15 +32,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:policies-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:policies-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/orgpolicy.policyAdmin
+  bindings:
+    - role: roles/orgpolicy.policyAdmin
+      members:
+        - member: "serviceAccount:policies-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:policies-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: policies-sa-workload-identity-binding
   namespace: config-control # kpt-set: ${management-namespace}
@@ -48,12 +50,14 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-policies] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-policies]
   resourceRef:
     name: policies-sa
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
-  role: roles/iam.workloadIdentityUser
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-policies] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-policies]
 ---
 apiVersion: v1
 kind: Namespace

--- a/catalog/landing-zone/namespaces/projects.yaml
+++ b/catalog/landing-zone/namespaces/projects.yaml
@@ -24,7 +24,7 @@ spec:
   displayName: projects-sa
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: projects-sa-projectcreator-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -32,15 +32,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/resourcemanager.projectCreator
+  bindings:
+    - role: roles/resourcemanager.projectCreator
+      members:
+        - member:  "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: projects-sa-projectmover-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -48,15 +50,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/resourcemanager.projectMover
+  bindings:
+    - role: roles/resourcemanager.projectMover
+      members:
+        - member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: projects-sa-projectdeleter-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -64,15 +68,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/resourcemanager.projectDeleter
+  bindings:
+    - role: roles/resourcemanager.projectDeleter
+      members:
+        - member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: projects-sa-billinguser-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -80,15 +86,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/billing.user
+  bindings:
+    - role: roles/billing.user
+      members:
+        - member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: projects-sa-serviceusageadmin-permissions
   namespace: config-control # kpt-set: ${management-namespace}
@@ -96,15 +104,17 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Organization
     external: "123456789012" # kpt-set: ${org-id}
-  role: roles/serviceusage.serviceUsageAdmin
+  bindings:
+    - role: roles/serviceusage.serviceUsageAdmin
+      members:
+        - member: "serviceAccount:projects-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:projects-sa@${management-project-id}.iam.gserviceaccount.com
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: projects-sa-workload-identity-binding
   namespace: config-control # kpt-set: ${management-namespace}
@@ -112,12 +122,14 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.3.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-projects] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-projects]
   resourceRef:
     name: projects-sa
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
-  role: roles/iam.workloadIdentityUser
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-projects] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-projects]
 ---
 apiVersion: v1
 kind: Namespace

--- a/catalog/log-export/org/bigquery-export/README.md
+++ b/catalog/log-export/org/bigquery-export/README.md
@@ -31,13 +31,14 @@ export.yaml  bigquery.cnrm.cloud.google.com/v1beta1      BigQueryDataset  bqloge
 export.yaml  logging.cnrm.cloud.google.com/v1beta1       LoggingLogSink   123456789012-bqsink         logging
 export.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service          my-project-id-bigquery      projects
 iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  bq-project-iam-policy       logging
-iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  logging-sa-iam-permissions  config-control
+iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPartialPolicy  logging-sa-iam-permissions  config-control
 ```
 
 ## Resource References
 
 - [BigQueryDataset](https://cloud.google.com/config-connector/docs/reference/resource-docs/bigquery/bigquerydataset)
 - [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
 - [LoggingLogSink](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogsink)
 - [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
 
@@ -79,4 +80,3 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  loggin
     ```
     kpt live status --output table --poll-until current
     ```
-

--- a/catalog/log-export/org/bigquery-export/iam.yaml
+++ b/catalog/log-export/org/bigquery-export/iam.yaml
@@ -31,16 +31,18 @@ spec:
   role: roles/bigquery.dataEditor
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+kind: IAMPartialPolicy
 metadata:
   name: logging-sa-iam-permissions
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.3.0
 spec:
-  member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
     external: projects/my-project-id # kpt-set: projects/${project-id}
-  role: roles/resourcemanager.projectIamAdmin
+  bindings:
+    - role: roles/resourcemanager.projectIamAdmin
+      members:
+        - member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com

--- a/catalog/project/kcc-namespace/README.md
+++ b/catalog/project/kcc-namespace/README.md
@@ -24,9 +24,9 @@ This package has no sub-packages.
 File                       APIVersion                          Kind                    Name                                               Namespace
 kcc-namespace-viewer.yaml  rbac.authorization.k8s.io/v1        RoleBinding             cnrm-network-viewer-project-id                     networking
 kcc-namespace-viewer.yaml  rbac.authorization.k8s.io/v1        RoleBinding             cnrm-project-viewer-project-id                     projects
-kcc-project-owner.yaml     iam.cnrm.cloud.google.com/v1beta1   IAMPolicyMember         kcc-project-id-owners-permissions                  projects
+kcc-project-owner.yaml     iam.cnrm.cloud.google.com/v1beta1   IAMPartialPolicy         kcc-project-id-owners-permissions                  projects
 kcc.yaml                   core.cnrm.cloud.google.com/v1beta1  ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  project-id
-kcc.yaml                   iam.cnrm.cloud.google.com/v1beta1   IAMPolicyMember         project-id-sa-workload-identity-binding            config-control
+kcc.yaml                   iam.cnrm.cloud.google.com/v1beta1   IAMPartialPolicy         project-id-sa-workload-identity-binding            config-control
 kcc.yaml                   iam.cnrm.cloud.google.com/v1beta1   IAMServiceAccount       kcc-project-id                                     config-control
 namespace.yaml             v1                                  Namespace               project-id
 ```
@@ -34,7 +34,7 @@ namespace.yaml             v1                                  Namespace        
 ## Resource References
 
 - [ConfigConnectorContext](https://cloud.google.com/config-connector/docs/how-to/advanced-install#addon-configuring)
-- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
 - [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)
 - [Namespace](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#namespace-v1-core)
 - [RoleBinding](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#rolebinding-v1-rbac-authorization-k8s-io)
@@ -77,4 +77,3 @@ namespace.yaml             v1                                  Namespace        
     ```
     kpt live status --output table --poll-until current
     ```
-


### PR DESCRIPTION
Switching the blueprints to use IAMPartialPolicy, where possible, instead of IAMPolicyMember.

A few places that use memberRef instead of member could not be converted as IAMPartialPolicy does not support memberRef.