### PR TITLE
feat: Add foundational IAM blueprint

### DIFF
--- a/catalog/iam-foundation/Kptfile
+++ b/catalog/iam-foundation/Kptfile
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: iam-foundation
+  annotations:
+    blueprints.cloud.google.com/title: Organizational Foundational IAM
+info:
+  description: This blueprint sets up recommended IAM roles for an enterprise organization in Google Cloud.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml
+    - image: gcr.io/kpt-fn/set-namespace:v0.1
+      configMap:
+        namespace: config-control

--- a/catalog/iam-foundation/README.md
+++ b/catalog/iam-foundation/README.md
@@ -1,0 +1,84 @@
+# Organizational Foundational IAM
+
+This blueprint sets up recommended IAM roles for an enterprise organization in Google Cloud.
+
+## Setters
+
+```
+Setter                 Usages
+group-devops           1
+group-network-admins   4
+group-org-admins       1
+group-security-admins  10
+org-id                 16
+```
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+```
+File             APIVersion                         Kind             Name                               Namespace
+devops.yaml      iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  foundation-devops-folders          config-control
+networking.yaml  iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  network-admins-compute             config-control
+networking.yaml  iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  network-admins-folders             config-control
+networking.yaml  iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  network-admins-security            config-control
+networking.yaml  iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  network-admins-shared-vpc          config-control
+org.yaml         iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  foundation-org-admin               config-control
+security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-bq                 config-control
+security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-custom-roles       config-control
+security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-folder-iam         config-control
+security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-gce                config-control
+security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-gke                config-control
+security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-log-config         config-control
+security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-org-policy         config-control
+security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-private-logs       config-control
+security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-scc                config-control
+security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-security-reviewer  config-control
+```
+
+## Resource References
+
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+
+## Usage
+
+1.  Clone the package:
+    ```
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/iam-foundation@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```
+    cd "./iam-foundation/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```
+    kpt live init --namespace ${NAMESPACE}"
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```
+    kpt live status --output table --poll-until current
+    ```
+

--- a/catalog/iam-foundation/devops.yaml
+++ b/catalog/iam-foundation/devops.yaml
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: foundation-devops-folders
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants permissions to view folders.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/resourcemanager.folderViewer
+  member: group:gcp-devops@example.com # kpt-set: group:${group-devops}

--- a/catalog/iam-foundation/networking.yaml
+++ b/catalog/iam-foundation/networking.yaml
@@ -1,0 +1,76 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: network-admins-compute
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants permissions to create, modify, and delete networking resources, except for firewall rules and SSL certificates.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/compute.networkAdmin
+  member: group:gcp-network-admins@example.com # kpt-set: group:${group-network-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: network-admins-shared-vpc
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants permissions to administer Shared VPC host projects.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/compute.xpnAdmin
+  member: group:gcp-network-admins@example.com # kpt-set: group:${group-network-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: network-admins-security
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants permissions to create, modify, and delete firewall rules and SSL certificates.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/compute.securityAdmin
+  member: group:gcp-network-admins@example.com # kpt-set: group:${group-network-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: network-admins-folders
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants permissions to view folders.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/resourcemanager.folderViewer
+  member: group:gcp-network-admins@example.com # kpt-set: group:${group-network-admins}

--- a/catalog/iam-foundation/org.yaml
+++ b/catalog/iam-foundation/org.yaml
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: foundation-org-admin
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: Access to administer all resources belonging to the organization.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/resourcemanager.organizationAdmin
+  member: group:gcp-organization-admins@example.com # kpt-set: group:${group-org-admins}

--- a/catalog/iam-foundation/security.yaml
+++ b/catalog/iam-foundation/security.yaml
@@ -1,0 +1,172 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: security-admins-org-policy
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants permission to set organizational policy constraints.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/orgpolicy.policyAdmin
+  member: group:gcp-security-admins@example.com # kpt-set: group:${group-security-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: security-admins-security-reviewer
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants permissions to view all resources for the organization, and to view the IAM policies that apply to them.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/iam.securityReviewer
+  member: group:gcp-security-admins@example.com # kpt-set: group:${group-security-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: security-admins-custom-roles
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants permissions to view all custom IAM roles in the organization, and to view the projects that they apply to.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/iam.roleViewer
+  member: group:gcp-security-admins@example.com # kpt-set: group:${group-security-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: security-admins-scc
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants administrator access to the Security Command Center.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/securitycenter.admin
+  member: group:gcp-security-admins@example.com # kpt-set: group:${group-security-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: security-admins-folder-iam
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants permissions to set folder-level IAM policies.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/resourcemanager.folderIamAdmin
+  member: group:gcp-security-admins@example.com # kpt-set: group:${group-security-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: security-admins-private-logs
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants read-only access to Cloud Logging features, including the ability to read private logs.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/logging.privateLogViewer
+  member: group:gcp-security-admins@example.com # kpt-set: group:${group-security-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: security-admins-log-config
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants permissions to create logs-based metrics and export sinks.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/logging.configWriter
+  member: group:gcp-security-admins@example.com # kpt-set: group:${group-security-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: security-admins-gke
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants read-only access to Google Kubernetes Engine resources.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/container.viewer
+  member: group:gcp-security-admins@example.com # kpt-set: group:${group-security-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: security-admins-gce
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants read-only access to Compute Engine resources.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/compute.viewer
+  member: group:gcp-security-admins@example.com # kpt-set: group:${group-security-admins}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: security-admins-bq
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/org-iam/v0.4.0
+    blueprints.cloud.google.com/description: This grants read-only access to BigQuery datasets.
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "123456789012" # kpt-set: ${org-id}
+  role: roles/bigquery.dataViewer
+  member: group:gcp-security-admins@example.com # kpt-set: group:${group-security-admins}

--- a/catalog/iam-foundation/setters.yaml
+++ b/catalog/iam-foundation/setters.yaml
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iam-setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  org-id: 123456789012
+  group-org-admins: gcp-organization-admins@example.com
+  group-security-admins: gcp-security-admins@example.com
+  group-network-admins: gcp-network-admins@example.com
+  group-devops: gcp-devops@example.com


### PR DESCRIPTION
Extracts the foundational IAM blueprint into its own package which can be used independently or as part of a larger landing zone.