### PR TITLE
fix: use setter defaults in ACM config

### DIFF
--- a/catalog/acm/acm-membership-api.yaml
+++ b/catalog/acm/acm-membership-api.yaml
@@ -15,8 +15,8 @@
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
-  name: platform-project-id-cluster-name-gkehub # kpt-set: ${platform-project-id}-${cluster-name}-gkehub
-  namespace: platform-namespace # kpt-set: ${platform-namespace}
+  name: platform-project-id-cluster-cluster-name-gkehub # kpt-set: ${platform-project-id}-${cluster-name}-gkehub
+  namespace: config-control # kpt-set: ${platform-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
     cnrm.cloud.google.com/project-id: platform-project-id # kpt-set: ${platform-project-id}
@@ -27,8 +27,8 @@ spec:
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
-  name: platform-project-id-cluster-name-acm # kpt-set: ${platform-project-id}-${cluster-name}-acm
-  namespace: platform-namespace # kpt-set: ${platform-namespace}
+  name: platform-project-id-cluster-cluster-name-acm # kpt-set: ${platform-project-id}-${cluster-name}-acm
+  namespace: config-control # kpt-set: ${platform-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
     cnrm.cloud.google.com/project-id: platform-project-id # kpt-set: ${platform-project-id}

--- a/catalog/acm/config-mgmt-csr.yaml
+++ b/catalog/acm/config-mgmt-csr.yaml
@@ -14,8 +14,8 @@
 apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
 kind: GKEHubFeatureMembership
 metadata:
-  name: feature-membership-name # kpt-set: acm-membership-${cluster-name}
-  namespace: platform-namespace # kpt-set: ${platform-namespace}
+  name: acm-membership-cluster-name # kpt-set: acm-membership-${cluster-name}
+  namespace: config-control # kpt-set: ${platform-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
@@ -24,9 +24,9 @@ spec:
     external: project-id # kpt-set: ${project-id}
   location: global
   membershipRef:
-    name: membership-name # kpt-set: hub-membership-${cluster-name}
+    name: hub-membership-cluster-name # kpt-set: hub-membership-${cluster-name}
   featureRef:
-    name: feature-name # kpt-set: feat-acm-${cluster-name}
+    name: feat-acm-cluster-name # kpt-set: feat-acm-${cluster-name}
   configmanagement:
     version: 1.9.0 #kpt-set: ${acm-version}
     configSync:

--- a/catalog/acm/config-mgmt-iam.yaml
+++ b/catalog/acm/config-mgmt-iam.yaml
@@ -16,27 +16,27 @@
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
-  name: sa-acm-gke-cluster # kpt-set: sa-acm-${cluster-name}
-  namespace: platform-namespace # kpt-set: ${platform-namespace}
+  name: sa-acm-cluster-name # kpt-set: sa-acm-${cluster-name}
+  namespace: config-control # kpt-set: ${platform-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
-  displayName: sa-acm-gke-cluster # kpt-set: sa-acm-${cluster-name}
+  displayName: sa-acm-cluster-name # kpt-set: sa-acm-${cluster-name}
   description: For use with ACM to provide read access to Cloud Source Repositories
 ---
 # Allow ACM Config Sync Kubernetes ServiceAccount (KSA) for root-reconciler to use the ACM GSA
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
 metadata:
-  name: sa-acm-gke-cluster # kpt-set: sa-acm-${cluster-name}
-  namespace: platform-namespace # kpt-set: ${platform-namespace}
+  name: sa-acm-cluster-name # kpt-set: sa-acm-${cluster-name}
+  namespace: config-control # kpt-set: ${platform-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:
   resourceRef:
-    name: sa-acm-gke-cluster # kpt-set: sa-acm-${cluster-name}
+    name: sa-acm-cluster-name # kpt-set: sa-acm-${cluster-name}
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
   bindings:
@@ -49,7 +49,7 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
 metadata:
   name: source-reader-sync-cluster-name-project-id # kpt-set: source-reader-sync-${cluster-name}-${project-id}
-  namespace: platform-namespace # kpt-set: ${platform-namespace}
+  namespace: config-control # kpt-set: ${platform-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
@@ -57,8 +57,8 @@ spec:
   resourceRef:
     apiVersion: sourcerepo.cnrm.cloud.google.com/v1beta1
     kind: SourceRepoRepository
-    external: projects/project-id/repos/name # kpt-set: ${sync-repo-ref}
+    external: projects/project-id/repos/repo-name # kpt-set: ${sync-repo-ref}
   bindings:
     - role: roles/source.reader
       members:
-        - member: serviceAccount:sync-gke-cluster@project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:sa-acm-${cluster-name}@${project-id}.iam.gserviceaccount.com
+        - member: serviceAccount:sa-acm-cluster-name@project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:sa-acm-${cluster-name}@${project-id}.iam.gserviceaccount.com

--- a/catalog/acm/feat-config-mgmt.yaml
+++ b/catalog/acm/feat-config-mgmt.yaml
@@ -14,8 +14,8 @@
 apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
 kind: GKEHubFeature
 metadata:
-  name: feature-name # kpt-set: feat-acm-${cluster-name}
-  namespace: platform-namespace # kpt-set: ${platform-namespace}
+  name: feat-acm-cluster-name # kpt-set: feat-acm-${cluster-name}
+  namespace: config-control # kpt-set: ${platform-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}

--- a/catalog/acm/membership.yaml
+++ b/catalog/acm/membership.yaml
@@ -14,8 +14,8 @@
 apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
 kind: GKEHubMembership
 metadata:
-  name: membership-name # kpt-set: hub-membership-${cluster-name}
-  namespace: platform-namespace # kpt-set: ${platform-namespace}
+  name: hub-membership-cluster-name # kpt-set: hub-membership-${cluster-name}
+  namespace: config-control # kpt-set: ${platform-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
@@ -23,8 +23,8 @@ spec:
   location: global
   authority:
     # Issuer must contain a link to a valid JWT issuer.
-    issuer: https://container.googleapis.com/v1/projects/project-id/locations/location/clusters/cluster-name # kpt-set: https://container.googleapis.com/v1/projects/${project-id}/locations/${location}/clusters/${cluster-name}
+    issuer: https://container.googleapis.com/v1/projects/project-id/locations/us-east4/clusters/cluster-name # kpt-set: https://container.googleapis.com/v1/projects/${project-id}/locations/${location}/clusters/${cluster-name}
   endpoint:
     gkeCluster:
       resourceRef:
-        external: //container.googleapis.com/projects/project-id/locations/location/clusters/cluster-name # kpt-set: //container.googleapis.com/projects/${project-id}/locations/${location}/clusters/${cluster-name}
+        external: //container.googleapis.com/projects/project-id/locations/us-east4/clusters/cluster-name # kpt-set: //container.googleapis.com/projects/${project-id}/locations/${location}/clusters/${cluster-name}

--- a/catalog/acm/services.yaml
+++ b/catalog/acm/services.yaml
@@ -16,7 +16,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   name: project-id-cluster-name-gkehub # kpt-set: ${project-id}-${cluster-name}-gkehub
-  namespace: platform-namespace # kpt-set: ${platform-namespace}
+  namespace: config-control # kpt-set: ${platform-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
@@ -28,7 +28,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   name: project-id-cluster-name-acm # kpt-set: ${project-id}-${cluster-name}-acm
-  namespace: platform-namespace # kpt-set: ${platform-namespace}
+  namespace: config-control # kpt-set: ${platform-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}


### PR DESCRIPTION
I noticed the setters and actual values in configuration had diverged. This renders config with the setter defaults.