### PR TITLE
chore: explicit release as for acm and anthos-cluster

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -50,11 +50,13 @@
       },
       "catalog/acm": {
         "package-name": "acm-blueprint",
-        "changelog-path": "CHANGELOG.md"
+        "changelog-path": "CHANGELOG.md",
+        "release-as": "0.1.0"
       },
       "catalog/anthos-cluster": {
         "package-name": "anthos-cluster-blueprint",
-        "changelog-path": "CHANGELOG.md"
+        "changelog-path": "CHANGELOG.md",
+        "release-as": "0.1.0"
       }
     },
     "bootstrap-sha": "dc9e8fe511c009536064cb2b677e6ceff52f1b1f",


### PR DESCRIPTION
release-please ignores commits before previous release PR #82 and is ignoring #83 and #87 commit messages prefixed with `feat:` for calculating new release semver. This PR should force release-please to release as a specified version to work around this.