### PR TITLE
fix: add correct attribution for lz lite

### DIFF
--- a/catalog/landing-zone-lite/iam.yaml
+++ b/catalog/landing-zone-lite/iam.yaml
@@ -17,7 +17,7 @@ metadata:
   name: org-admins-iam
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
 spec:
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
@@ -32,7 +32,7 @@ metadata:
   name: billing-admins-iam
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
 spec:
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1

--- a/catalog/landing-zone-lite/namespaces/hierarchy.yaml
+++ b/catalog/landing-zone-lite/namespaces/hierarchy.yaml
@@ -17,7 +17,7 @@ metadata:
   name: hierarchy-sa
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   displayName: hierarchy-sa
@@ -28,7 +28,7 @@ metadata:
   name: hierarchy-sa-folderadmin-permissions
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:
@@ -44,7 +44,7 @@ metadata:
   name: hierarchy-sa-workload-identity-binding
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:
@@ -83,6 +83,6 @@ metadata:
   name: configconnectorcontext.core.cnrm.cloud.google.com
   namespace: hierarchy
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
 spec:
   googleServiceAccount: hierarchy-sa@management-project-id.iam.gserviceaccount.com # kpt-set: hierarchy-sa@${management-project-id}.iam.gserviceaccount.com

--- a/catalog/landing-zone-lite/namespaces/projects.yaml
+++ b/catalog/landing-zone-lite/namespaces/projects.yaml
@@ -17,7 +17,7 @@ metadata:
   name: projects-sa
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   displayName: projects-sa
@@ -28,7 +28,7 @@ metadata:
   name: projects-sa-projectiamadmin-permissions
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:
@@ -44,7 +44,7 @@ metadata:
   name: projects-sa-projectcreator-permissions
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:
@@ -60,7 +60,7 @@ metadata:
   name: projects-sa-projectmover-permissions
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:
@@ -76,7 +76,7 @@ metadata:
   name: projects-sa-projectdeleter-permissions
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:
@@ -92,7 +92,7 @@ metadata:
   name: projects-sa-billinguser-permissions
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:
@@ -108,7 +108,7 @@ metadata:
   name: projects-sa-serviceusageadmin-permissions
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:
@@ -124,7 +124,7 @@ metadata:
   name: projects-sa-workload-identity-binding
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:

--- a/catalog/landing-zone-lite/services.yaml
+++ b/catalog/landing-zone-lite/services.yaml
@@ -17,7 +17,7 @@ metadata:
   name: management-project-id # kpt-set: ${management-project-id}
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.4.0
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/deletion-policy: "abandon"
     config.kubernetes.io/local-config: "true"
 spec:


### PR DESCRIPTION
Workaround for https://github.com/GoogleCloudPlatform/blueprints/issues/121 to unblock release. This PR sets the correct attribution.