### PR TITLE
chore: remove bootstrap release-as

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -50,18 +50,15 @@
       },
       "catalog/acm": {
         "package-name": "acm-blueprint",
-        "changelog-path": "CHANGELOG.md",
-        "release-as": "0.1.0"
+        "changelog-path": "CHANGELOG.md"
       },
       "catalog/anthos-cluster": {
         "package-name": "anthos-cluster-blueprint",
-        "changelog-path": "CHANGELOG.md",
-        "release-as": "0.1.0"
+        "changelog-path": "CHANGELOG.md"
       },
       "catalog/landing-zone-lite": {
         "package-name": "landing-zone-lite-blueprint",
-        "changelog-path": "CHANGELOG.md",
-        "release-as": "0.1.0"
+        "changelog-path": "CHANGELOG.md"
       }
     },
     "bootstrap-sha": "dc9e8fe511c009536064cb2b677e6ceff52f1b1f",


### PR DESCRIPTION
This removed explicit release-as added for release please to force release as 0.1.0 in https://github.com/GoogleCloudPlatform/blueprints/pull/117 now that 0.1.0 releases exist.