### PR TITLE
chore: format meta resources

### DIFF
--- a/catalog/acm/setters.yaml
+++ b/catalog/acm/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata: # kpt-merge: /setters

--- a/catalog/anthos-cluster/acm/setters.yaml
+++ b/catalog/anthos-cluster/acm/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata: # kpt-merge: /setters

--- a/catalog/anthos-cluster/gke/cluster/setters.yaml
+++ b/catalog/anthos-cluster/gke/cluster/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata: # kpt-merge: /setters

--- a/catalog/anthos-cluster/gke/nodepools/primary/setters.yaml
+++ b/catalog/anthos-cluster/gke/nodepools/primary/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata: # kpt-merge: /setters

--- a/catalog/anthos-cluster/gke/setters.yaml
+++ b/catalog/anthos-cluster/gke/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata: # kpt-merge: /setters

--- a/catalog/anthos-cluster/setters.yaml
+++ b/catalog/anthos-cluster/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/bucket/setters.yaml
+++ b/catalog/bucket/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/gke/cluster/setters.yaml
+++ b/catalog/gke/cluster/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/gke/nodepools/primary/setters.yaml
+++ b/catalog/gke/nodepools/primary/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/gke/setters.yaml
+++ b/catalog/gke/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/hierarchy/bu/setters.yaml
+++ b/catalog/hierarchy/bu/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/hierarchy/env-bu/setters.yaml
+++ b/catalog/hierarchy/env-bu/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/hierarchy/simple/setters.yaml
+++ b/catalog/hierarchy/simple/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/hierarchy/team/setters.yaml
+++ b/catalog/hierarchy/team/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/iam-foundation/setters.yaml
+++ b/catalog/iam-foundation/setters.yaml
@@ -18,7 +18,7 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 data:
-  org-id: 123456789012
+  org-id: "123456789012"
   group-org-admins: gcp-organization-admins@example.com
   group-security-admins: gcp-security-admins@example.com
   group-network-admins: gcp-network-admins@example.com

--- a/catalog/landing-zone-lite/setters.yaml
+++ b/catalog/landing-zone-lite/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/landing-zone/setters.yaml
+++ b/catalog/landing-zone/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/log-export/folder/bigquery-export/setters.yaml
+++ b/catalog/log-export/folder/bigquery-export/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/log-export/folder/pubsub-export/setters.yaml
+++ b/catalog/log-export/folder/pubsub-export/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/log-export/folder/storage-export/setters.yaml
+++ b/catalog/log-export/folder/storage-export/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/log-export/org/bigquery-export/setters.yaml
+++ b/catalog/log-export/org/bigquery-export/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/log-export/org/pubsub-export/setters.yaml
+++ b/catalog/log-export/org/pubsub-export/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/log-export/org/storage-export/setters.yaml
+++ b/catalog/log-export/org/storage-export/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/dns/managedzone-forwarding/setters.yaml
+++ b/catalog/networking/dns/managedzone-forwarding/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/dns/managedzone-peering/setters.yaml
+++ b/catalog/networking/dns/managedzone-peering/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/dns/managedzone-private/setters.yaml
+++ b/catalog/networking/dns/managedzone-private/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/dns/policy/setters.yaml
+++ b/catalog/networking/dns/policy/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/dns/recordset/setters.yaml
+++ b/catalog/networking/dns/recordset/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/firewall/common-rules/Kptfile
+++ b/catalog/networking/firewall/common-rules/Kptfile
@@ -35,5 +35,5 @@ info:
             SSL, HTTP (8080), and ICMP traffic on all RFC1918 ranges
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
-      configPath: setters.yaml
+  - image: gcr.io/kpt-fn/apply-setters:v0.1
+    configPath: setters.yaml

--- a/catalog/networking/firewall/common-rules/setters.yaml
+++ b/catalog/networking/firewall/common-rules/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/network/Kptfile
+++ b/catalog/networking/network/Kptfile
@@ -37,5 +37,5 @@ info:
         to use when authenticating with the VPN.
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
-      configPath: setters.yaml
+  - image: gcr.io/kpt-fn/apply-setters:v0.1
+    configPath: setters.yaml

--- a/catalog/networking/network/setters.yaml
+++ b/catalog/networking/network/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/network/subnet/setters.yaml
+++ b/catalog/networking/network/subnet/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/network/vpc/setters.yaml
+++ b/catalog/networking/network/vpc/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/peering/setters.yaml
+++ b/catalog/networking/peering/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/routes/routes-igw/setters.yaml
+++ b/catalog/networking/routes/routes-igw/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/shared-vpc/setters.yaml
+++ b/catalog/networking/shared-vpc/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/svpc-service-project/setters.yaml
+++ b/catalog/networking/svpc-service-project/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/vpc-service-controls/access-policy/setters.yaml
+++ b/catalog/networking/vpc-service-controls/access-policy/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/networking/vpc-service-controls/perimeter/setters.yaml
+++ b/catalog/networking/vpc-service-controls/perimeter/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/project/kcc-namespace/setters.yaml
+++ b/catalog/project/kcc-namespace/setters.yaml
@@ -11,13 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: setters
   annotations:
-    config.kubernetes.io/local-config: true
+    config.kubernetes.io/local-config: "true"
 data:
   management-namespace: config-control
   management-project-id: management-project-id

--- a/catalog/project/kcc-namespace/validation.yaml
+++ b/catalog/project/kcc-namespace/validation.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: fn.kpt.dev/v1alpha1
 kind: StarlarkRun
 metadata:
@@ -31,18 +30,18 @@ source: |
       if resource["kind"] == "IAMPartialPolicy" and resource["metadata"]["name"].endswith("owners-permissions"):
         return resource["metadata"]["namespace"]
     fail("unable to find project owner IAMPartialPolicy")
-  
+
   def get_mgmt_ns(resource_list):
     for resource in resource_list["items"]:
       # IAMServiceAccount is expected to be in management ns
       if resource["kind"] == "IAMServiceAccount" and resource["metadata"]["name"].startswith("kcc-"):
         return resource["metadata"]["namespace"]
     fail("unable to find project KCC SA")
-    
+
   tenant_ns = get_tenant_ns(ctx.resource_list)
   projects_ns = get_projects_ns(ctx.resource_list)
   mgmt_ns = get_mgmt_ns(ctx.resource_list)
-  
+
   if tenant_ns == projects_ns:
     fail("projects-namespace cannot be the same as tenant project")
   if tenant_ns == mgmt_ns:

--- a/catalog/project/setters.yaml
+++ b/catalog/project/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/redis-bucket/setters.yaml
+++ b/catalog/redis-bucket/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/catalog/spanner/setters.yaml
+++ b/catalog/spanner/setters.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/utils/lint.sh
+++ b/utils/lint.sh
@@ -47,7 +47,7 @@ check_yaml_fmt(){
     catalogTmpDir="$tmpDir/catalog"
     # format tmpDir blueprints
     # todo: switch to kpt v1 after v1 branch merged
-    kpt fn eval "$catalogTmpDir" --image gcr.io/kpt-fn/format:unstable > /dev/null
+    kpt fn eval "$catalogTmpDir" --image gcr.io/kpt-fn/format:unstable --include-meta-resources > /dev/null
     local diffExitCode=1
     # check if both formatted and current are same
     diff -qr catalog "$catalogTmpDir" && diffExitCode=$? || diffExitCode=$?
@@ -69,7 +69,7 @@ fix_license(){
 
 fix_yaml_fmt(){
     echo "Fix yaml format"
-    kpt fn eval catalog --image gcr.io/kpt-fn/format:unstable
+    kpt fn eval catalog --image gcr.io/kpt-fn/format:unstable --include-meta-resources
 }
 
 check_lint(){


### PR DESCRIPTION
Linter was previously ignoring fn config and other meta resources while formatting