### PR TITLE
fix: bump kpt version in hydration pipeline

### DIFF
--- a/catalog/gitops/hydration-trigger.yaml
+++ b/catalog/gitops/hydration-trigger.yaml
@@ -42,7 +42,7 @@ spec:
         entrypoint: /bin/sh
         id: "Clone Deployment Repo"
         timeout: 300s
-      - name: gcr.io/kpt-dev/kpt:v1.0.0-beta.1
+      - name: gcr.io/kpt-dev/kpt:v1.0.0-beta.9
         volumes:
           - name: hydrated-workspace
             path: /hydrated-workspace


### PR DESCRIPTION
Update kpt to version kpt:v1.0.0-beta.9.
Using the current version with the landing-zone blueprint fails with the following error for the workspace package:

Package "workspace": 
error: resources must be annotated with config.kubernetes.io/index to be written to files

Upgrading to this version solved the issue.