### PR TITLE
chore: regenerate docs using docs kfn

### DIFF
--- a/catalog/acm/README.md
+++ b/catalog/acm/README.md
@@ -1,20 +1,24 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # ACM blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A blueprint to install Anthos Config Management (ACM) on an existing GKE cluster. The installation is done by enrolling the cluster into GKE Hub Membership, enabling and configuring the ACM feature.
 
 ## Setters
 
-```
-Setter              Usages
-acm-version         0
-cluster-name        16
-location            2
-platform-namespace  8
-policy-dir          1
-project-id          18
-sync-repo           1
-sync-repo-ref       1
-```
+|        Name         |                          Value                           | Type | Count |
+|---------------------|----------------------------------------------------------|------|-------|
+| acm-version         | 1.9.0                                                    | str  |     0 |
+| cluster-name        | cluster-name                                             | str  |    18 |
+| location            | us-east4                                                 | str  |     2 |
+| platform-namespace  | config-control                                           | str  |    10 |
+| platform-project-id | platform-project-id-cluster-cluster                      | str  |     4 |
+| policy-dir          | config/root                                              | str  |     1 |
+| project-id          | project-id                                               | str  |    18 |
+| sync-repo           | https://source.developers.google.com/p/project_id/r/repo | str  |     1 |
+| sync-repo-ref       | projects/project-id/repos/repo-name                      | str  |     1 |
 
 ## Sub-packages
 
@@ -22,17 +26,18 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                   APIVersion                                  Kind                     Name                                        Namespace
-config-mgmt-csr.yaml   gkehub.cnrm.cloud.google.com/v1beta1        GKEHubFeatureMembership  feature-membership-name                     platform-namespace
-config-mgmt-iam.yaml   iam.cnrm.cloud.google.com/v1beta1           IAMPartialPolicy         sa-acm-gke-cluster                          platform-namespace
-config-mgmt-iam.yaml   iam.cnrm.cloud.google.com/v1beta1           IAMPartialPolicy         source-reader-sync-cluster-name-project-id  platform-namespace
-config-mgmt-iam.yaml   iam.cnrm.cloud.google.com/v1beta1           IAMServiceAccount        sa-acm-gke-cluster                          platform-namespace
-feat-config-mgmt.yaml  gkehub.cnrm.cloud.google.com/v1beta1        GKEHubFeature            feature-name                                platform-namespace
-membership.yaml        gkehub.cnrm.cloud.google.com/v1beta1        GKEHubMembership         membership-name                             platform-namespace
-services.yaml          serviceusage.cnrm.cloud.google.com/v1beta1  Service                  project-id-cluster-name-acm                 platform-namespace
-services.yaml          serviceusage.cnrm.cloud.google.com/v1beta1  Service                  project-id-cluster-name-gkehub              platform-namespace
-```
+|          File           |                 APIVersion                 |          Kind           |                      Name                       |   Namespace    |
+|-------------------------|--------------------------------------------|-------------------------|-------------------------------------------------|----------------|
+| acm-membership-api.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                 | platform-project-id-cluster-cluster-name-gkehub | config-control |
+| acm-membership-api.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                 | platform-project-id-cluster-cluster-name-acm    | config-control |
+| config-mgmt-csr.yaml    | gkehub.cnrm.cloud.google.com/v1beta1       | GKEHubFeatureMembership | acm-membership-cluster-name                     | config-control |
+| config-mgmt-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1          | IAMServiceAccount       | sa-acm-cluster-name                             | config-control |
+| config-mgmt-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1          | IAMPartialPolicy        | sa-acm-cluster-name                             | config-control |
+| config-mgmt-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1          | IAMPartialPolicy        | source-reader-sync-cluster-name-project-id      | config-control |
+| feat-config-mgmt.yaml   | gkehub.cnrm.cloud.google.com/v1beta1       | GKEHubFeature           | feat-acm-cluster-name                           | config-control |
+| membership.yaml         | gkehub.cnrm.cloud.google.com/v1beta1       | GKEHubMembership        | hub-membership-cluster-name                     | config-control |
+| services.yaml           | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                 | project-id-cluster-name-gkehub                  | config-control |
+| services.yaml           | serviceusage.cnrm.cloud.google.com/v1beta1 | Service                 | project-id-cluster-name-acm                     | config-control |
 
 ## Resource References
 
@@ -46,14 +51,14 @@ services.yaml          serviceusage.cnrm.cloud.google.com/v1beta1  Service      
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/acm@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./acm/"
     ```
 
@@ -61,24 +66,25 @@ services.yaml          serviceusage.cnrm.cloud.google.com/v1beta1  Service      
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/anthos-cluster/README.md
+++ b/catalog/anthos-cluster/README.md
@@ -1,35 +1,40 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Anthos cluster blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A blueprint to create an Anthos cluster and install Anthos Config Management (ACM) on the cluster. The ACM installation is done by enrolling the cluster into GKE Hub Membership, enabling and configuring the ACM feature. An existing subnet needs to be provided where the cluster should be created.
 
 ## Setters
 
-```
-Setter               Usages
-acm-version          0
-cluster-name         29
-location             4
-master-ip-range      1
-max-node-count       1
-network-ref          1
-nodepool-name        11
-platform-namespace   17
-pods-range-name      1
-policy-dir           1
-project-id           27
-projects-namespace   1
-security-group       1
-services-range-name  1
-subnet-ref           1
-sync-repo            1
-sync-repo-ref        1
-```
+|        Name         |                             Value                              | Type | Count |
+|---------------------|----------------------------------------------------------------|------|-------|
+| acm-version         | 1.9.0                                                          | str  |     0 |
+| cluster-name        | example-us-west4                                               | str  |    25 |
+| location            | us-east4                                                       | str  |     4 |
+| master-ip-range     | 10.254.0.0/28                                                  | str  |     1 |
+| max-node-count      |                                                              2 | int  |     1 |
+| network-ref         | projects/network-project-id/global/networks/default            | str  |     1 |
+| nodepool-name       | primary                                                        | str  |    11 |
+| platform-namespace  | config-control                                                 | str  |    19 |
+| platform-project-id | platform-project-id-cluster                                    | str  |     4 |
+| pods-range-name     | pods                                                           | str  |     1 |
+| policy-dir          | config/root                                                    | str  |     1 |
+| project-id          | project-id                                                     | str  |    26 |
+| projects-namespace  | projects                                                       | str  |     1 |
+| security-group      | gke-security-groups@example.com                                | str  |     1 |
+| services-range-name | services                                                       | str  |     1 |
+| subnet-ref          | projects/network-project-id/regions/region/subnetworks/default | str  |     1 |
+| sync-repo           | https://source.developers.google.com/p/project_id/r/repo       | str  |     1 |
+| sync-repo-ref       | projects/project-id/repos/repo-name                            | str  |     1 |
 
 ## Sub-packages
 
-- [acm](/catalog/anthos-cluster/acm)
-- [cluster](/catalog/anthos-cluster/cluster)
-- [nodepools/primary](/catalog/anthos-cluster/nodepools/primary)
+- [acm](acm)
+- [gke-cluster](gke/cluster)
+- [gke-nodepool](gke/nodepools/primary)
+- [gke](gke)
 
 ## Resources
 
@@ -42,14 +47,14 @@ This package has no top-level resources. See sub-packages.
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/anthos-cluster@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./anthos-cluster/"
     ```
 
@@ -57,24 +62,25 @@ This package has no top-level resources. See sub-packages.
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/bucket/README.md
+++ b/catalog/bucket/README.md
@@ -1,16 +1,19 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Google Cloud Storage Bucket blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A Google Cloud Storage bucket
 
 ## Setters
 
-```
-Setter         Usages
-name           1
-namespace      1
-project-id     2
-storage-class  1
-```
+|     Name      |       Value        | Type | Count |
+|---------------|--------------------|------|-------|
+| name          | bucket2            | str  |     1 |
+| namespace     | config-control     | str  |     1 |
+| project-id    | blueprints-project | str  |     2 |
+| storage-class | standard           | str  |     1 |
 
 ## Sub-packages
 
@@ -18,10 +21,9 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File         APIVersion                             Kind           Name                       Namespace
-bucket.yaml  storage.cnrm.cloud.google.com/v1beta1  StorageBucket  blueprints-project-bucket  config-control
-```
+|    File     |              APIVersion               |     Kind      |           Name            |   Namespace    |
+|-------------|---------------------------------------|---------------|---------------------------|----------------|
+| bucket.yaml | storage.cnrm.cloud.google.com/v1beta1 | StorageBucket | blueprints-project-bucket | config-control |
 
 ## Resource References
 
@@ -30,14 +32,14 @@ bucket.yaml  storage.cnrm.cloud.google.com/v1beta1  StorageBucket  blueprints-pr
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/bucket@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./bucket/"
     ```
 
@@ -45,24 +47,25 @@ bucket.yaml  storage.cnrm.cloud.google.com/v1beta1  StorageBucket  blueprints-pr
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/empty/README.md
+++ b/catalog/empty/README.md
@@ -1,5 +1,9 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Empty blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 An example of an empty blueprint.
 
 ## Setters
@@ -12,48 +16,51 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File       APIVersion  Kind       Name  Namespace
-noop.yaml  v1          ConfigMap  noop  config-control
-```
+|   File    | APIVersion |   Kind    | Name |   Namespace    |
+|-----------|------------|-----------|------|----------------|
+| noop.yaml | v1         | ConfigMap | noop | config-control |
 
 ## Resource References
 
-- [ConfigMap](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#configmap-v1-core)
+- [ConfigMap](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#configmap-v1-core)
 
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/empty@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./empty/"
     ```
 
+1.  Edit the function config file(s):
+    - setters.yaml
+
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/gitops/README.md
+++ b/catalog/gitops/README.md
@@ -1,5 +1,9 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # CSR GitOps Pipeline blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A GitOps Continuous Deployment pipeline using Anthos Config Management (ACM),
 Cloud Source Repository (CSR), and Cloud Build.
 
@@ -15,33 +19,31 @@ After installing this blueprint, you will be able to:
 
 ## Setters
 
-```
-Setter           Usages
-cluster-name     9
-configsync-dir   1
-deployment-repo  4
-namespace        10
-project-id       16
-project-number   2
-source-repo      5
-```
+|      Name       |      Value      | Type | Count |
+|-----------------|-----------------|------|-------|
+| cluster-name    | cluster-name    | str  |     9 |
+| configsync-dir  | config          | str  |     1 |
+| deployment-repo | deployment-repo | str  |     4 |
+| namespace       | config-control  | str  |    10 |
+| project-id      | project-id      | str  |    16 |
+| project-number  |   1234567890123 | str  |     2 |
+| source-repo     | source-repo     | str  |     5 |
 
 ## Sub-packages
 
-- [configsync](/catalog/gitops/configsync)
+- [configsync-csr](configsync)
 
 ## Resources
 
-```
-File                      APIVersion                                  Kind                  Name                              Namespace
-cloudbuild-iam.yaml       iam.cnrm.cloud.google.com/v1beta1           IAMPartialPolicy       deployment-repo-cloudbuild-write  config-control
-cloudbuild-iam.yaml       iam.cnrm.cloud.google.com/v1beta1           IAMPartialPolicy       source-repo-cloudbuild-read       config-control
-hydration-trigger.yaml    cloudbuild.cnrm.cloud.google.com/v1beta1    CloudBuildTrigger     source-repo-cicd-trigger          config-control
-services.yaml             serviceusage.cnrm.cloud.google.com/v1beta1  Service               cloudbuild.googleapis.com         config-control
-services.yaml             serviceusage.cnrm.cloud.google.com/v1beta1  Service               sourcerepo.googleapis.com         config-control
-source-repositories.yaml  sourcerepo.cnrm.cloud.google.com/v1beta1    SourceRepoRepository  deployment-repo                   config-control
-source-repositories.yaml  sourcerepo.cnrm.cloud.google.com/v1beta1    SourceRepoRepository  source-repo                       config-control
-```
+|           File           |                 APIVersion                 |         Kind         |               Name               |   Namespace    |
+|--------------------------|--------------------------------------------|----------------------|----------------------------------|----------------|
+| cloudbuild-iam.yaml      | iam.cnrm.cloud.google.com/v1beta1          | IAMPartialPolicy     | deployment-repo-cloudbuild-write | config-control |
+| cloudbuild-iam.yaml      | iam.cnrm.cloud.google.com/v1beta1          | IAMPartialPolicy     | source-repo-cloudbuild-read      | config-control |
+| hydration-trigger.yaml   | cloudbuild.cnrm.cloud.google.com/v1beta1   | CloudBuildTrigger    | source-repo-cicd-trigger         | config-control |
+| services.yaml            | serviceusage.cnrm.cloud.google.com/v1beta1 | Service              | sourcerepo.googleapis.com        | config-control |
+| services.yaml            | serviceusage.cnrm.cloud.google.com/v1beta1 | Service              | cloudbuild.googleapis.com        | config-control |
+| source-repositories.yaml | sourcerepo.cnrm.cloud.google.com/v1beta1   | SourceRepoRepository | source-repo                      | config-control |
+| source-repositories.yaml | sourcerepo.cnrm.cloud.google.com/v1beta1   | SourceRepoRepository | deployment-repo                  | config-control |
 
 ## Resource References
 
@@ -53,38 +55,40 @@ source-repositories.yaml  sourcerepo.cnrm.cloud.google.com/v1beta1    SourceRepo
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gitops@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gitops-csr@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./gitops/"
+    ```shell
+    cd "./gitops-csr/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/gitops/README.md
+++ b/catalog/gitops/README.md
@@ -56,14 +56,14 @@ After installing this blueprint, you will be able to:
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gitops-csr@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gitops@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./gitops-csr/"
+    cd "./gitops/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/gitops/configsync/README.md
+++ b/catalog/gitops/configsync/README.md
@@ -1,5 +1,9 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # CSR ConfigSync blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A GitOps Continuous Deployment pipeline using Anthos Config Management (ACM)
 and Cloud Source Repository (CSR).
 
@@ -12,14 +16,13 @@ After installing this blueprint, you will be able to:
 
 ## Setters
 
-```
-Setter           Usages
-cluster-name     8
-configsync-dir   1
-deployment-repo  1
-namespace        3
-project-id       9
-```
+|      Name       |      Value      | Type | Count |
+|-----------------|-----------------|------|-------|
+| cluster-name    | cluster-name    | str  |     8 |
+| configsync-dir  | config          | str  |     1 |
+| deployment-repo | deployment-repo | str  |     1 |
+| namespace       | config-control  | str  |     3 |
+| project-id      | project-id      | str  |     9 |
 
 ## Sub-packages
 
@@ -27,13 +30,12 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                    APIVersion                         Kind               Name                                        Namespace
-config-management.yaml  configmanagement.gke.io/v1         ConfigManagement   config-management
-configsync-iam.yaml     iam.cnrm.cloud.google.com/v1beta1  IAMPartialPolicy    source-reader-sync-cluster-name-project-id  config-control
-configsync-iam.yaml     iam.cnrm.cloud.google.com/v1beta1  IAMPartialPolicy    sync-cluster-name                           config-control
-configsync-iam.yaml     iam.cnrm.cloud.google.com/v1beta1  IAMServiceAccount  sync-cluster-name                           config-control
-```
+|          File          |            APIVersion             |       Kind        |                    Name                    |   Namespace    |
+|------------------------|-----------------------------------|-------------------|--------------------------------------------|----------------|
+| config-management.yaml | configmanagement.gke.io/v1        | ConfigManagement  | config-management                          |                |
+| configsync-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1 | IAMServiceAccount | sync-cluster-name                          | config-control |
+| configsync-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1 | IAMPartialPolicy  | sync-cluster-name                          | config-control |
+| configsync-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1 | IAMPartialPolicy  | source-reader-sync-cluster-name-project-id | config-control |
 
 ## Resource References
 
@@ -44,38 +46,40 @@ configsync-iam.yaml     iam.cnrm.cloud.google.com/v1beta1  IAMServiceAccount  sy
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gitops/configsync@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gitops/configsync-csr@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./configsync/"
+    ```shell
+    cd "./configsync-csr/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/gitops/configsync/README.md
+++ b/catalog/gitops/configsync/README.md
@@ -47,14 +47,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gitops/configsync-csr@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gitops/configsync@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./configsync-csr/"
+    cd "./configsync/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/gke-autopilot/README.md
+++ b/catalog/gke-autopilot/README.md
@@ -1,26 +1,29 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # GKE Autopilot blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A blueprint to create a GKE Autopilot cluster. An existing subnet needs to be provided where the cluster should be created.
 
 ## Setters
 
-```
-Setter               Usages
-cluster-name         2
-location             1
-master-ip-range      1
-network-ref          1
-platform-namespace   1
-pods-range-name      1
-project-id           4
-projects-namespace   1
-services-range-name  1
-subnet-ref           1
-```
+|        Name         |                             Value                              | Type | Count |
+|---------------------|----------------------------------------------------------------|------|-------|
+| cluster-name        | example-us-west4                                               | str  |     2 |
+| location            | us-east4                                                       | str  |     1 |
+| master-ip-range     | 10.254.0.0/28                                                  | str  |     1 |
+| network-ref         | projects/network-project-id/global/networks/default            | str  |     1 |
+| platform-namespace  | config-control                                                 | str  |     1 |
+| pods-range-name     | pods                                                           | str  |     1 |
+| project-id          | project-id                                                     | str  |     4 |
+| projects-namespace  | projects                                                       | str  |     1 |
+| services-range-name | services                                                       | str  |     1 |
+| subnet-ref          | projects/network-project-id/regions/region/subnetworks/default | str  |     1 |
 
 ## Sub-packages
 
-- [cluster](/catalog/gke-autopilot/cluster)
+- [gke-cluster](cluster)
 
 ## Resources
 
@@ -33,14 +36,14 @@ This package has no top-level resources. See sub-packages.
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke-autopilot@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./gke-autopilot/"
     ```
 
@@ -48,24 +51,25 @@ This package has no top-level resources. See sub-packages.
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/gke/README.md
+++ b/catalog/gke/README.md
@@ -1,30 +1,33 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # GKE blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A GKE cluster with a primary node pool. An existing subnet needs to be provided where the cluster should be created.
 
 ## Setters
 
-```
-Setter               Usages
-cluster-name         13
-location             2
-master-ip-range      1
-max-node-count       1
-network-ref          1
-nodepool-name        11
-platform-namespace   9
-pods-range-name      1
-project-id           9
-projects-namespace   1
-security-group       1
-services-range-name  1
-subnet-ref           1
-```
+|        Name         |                             Value                              | Type | Count |
+|---------------------|----------------------------------------------------------------|------|-------|
+| cluster-name        | example-us-west4                                               | str  |    13 |
+| location            | us-east4                                                       | str  |     2 |
+| master-ip-range     | 10.254.0.0/28                                                  | str  |     1 |
+| max-node-count      |                                                              2 | int  |     1 |
+| network-ref         | projects/network-project-id/global/networks/default            | str  |     1 |
+| nodepool-name       | primary                                                        | str  |    11 |
+| platform-namespace  | config-control                                                 | str  |     9 |
+| pods-range-name     | pods                                                           | str  |     1 |
+| project-id          | project-id                                                     | str  |     9 |
+| projects-namespace  | projects                                                       | str  |     1 |
+| security-group      | gke-security-groups@example.com                                | str  |     1 |
+| services-range-name | services                                                       | str  |     1 |
+| subnet-ref          | projects/network-project-id/regions/region/subnetworks/default | str  |     1 |
 
 ## Sub-packages
 
-- [cluster](/catalog/gke/cluster)
-- [nodepools/primary](/catalog/gke/nodepools/primary)
+- [gke-cluster](cluster)
+- [gke-nodepool](nodepools/primary)
 
 ## Resources
 
@@ -37,14 +40,14 @@ This package has no top-level resources. See sub-packages.
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./gke/"
     ```
 
@@ -52,24 +55,25 @@ This package has no top-level resources. See sub-packages.
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/gke/cluster/README.md
+++ b/catalog/gke/cluster/README.md
@@ -42,14 +42,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke/gke-cluster@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke/cluster@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./gke-cluster/"
+    cd "./cluster/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/gke/cluster/README.md
+++ b/catalog/gke/cluster/README.md
@@ -1,23 +1,26 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # GKE Cluster blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A GKE cluster with public masters and private nodes
 
 ## Setters
 
-```
-Setter               Usages
-cluster-name         2
-location             1
-master-ip-range      1
-network-ref          1
-platform-namespace   1
-pods-range-name      1
-project-id           4
-projects-namespace   1
-security-group       1
-services-range-name  1
-subnet-ref           1
-```
+|        Name         |                             Value                              | Type | Count |
+|---------------------|----------------------------------------------------------------|------|-------|
+| cluster-name        | example-us-west4                                               | str  |     2 |
+| location            | us-east4                                                       | str  |     1 |
+| master-ip-range     | 10.254.0.0/28                                                  | str  |     1 |
+| network-ref         | projects/network-project-id/global/networks/default            | str  |     1 |
+| platform-namespace  | config-control                                                 | str  |     1 |
+| pods-range-name     | pods                                                           | str  |     1 |
+| project-id          | project-id                                                     | str  |     4 |
+| projects-namespace  | projects                                                       | str  |     1 |
+| security-group      | gke-security-groups@example.com                                | str  |     1 |
+| services-range-name | services                                                       | str  |     1 |
+| subnet-ref          | projects/network-project-id/regions/region/subnetworks/default | str  |     1 |
 
 ## Sub-packages
 
@@ -25,11 +28,10 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                APIVersion                                  Kind              Name                               Namespace
-cluster.yaml        container.cnrm.cloud.google.com/v1beta1     ContainerCluster  example-us-east4                   config-control
-container-api.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service           project-id-cluster-name-container  projects
-```
+|        File        |                 APIVersion                 |       Kind       |               Name                |   Namespace    |
+|--------------------|--------------------------------------------|------------------|-----------------------------------|----------------|
+| cluster.yaml       | container.cnrm.cloud.google.com/v1beta1    | ContainerCluster | example-us-east4                  | config-control |
+| container-api.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service          | project-id-cluster-name-container | projects       |
 
 ## Resource References
 
@@ -39,39 +41,40 @@ container-api.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service         
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke/cluster@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke/gke-cluster@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./cluster/"
+    ```shell
+    cd "./gke-cluster/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/gke/nodepools/primary/README.md
+++ b/catalog/gke/nodepools/primary/README.md
@@ -1,19 +1,22 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # GKE Node Pool blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A GKE node pool with a dedicated service account
 
 ## Setters
 
-```
-Setter              Usages
-cluster-name        11
-location            1
-max-node-count      1
-nodepool-name       11
-platform-namespace  8
-project-id          5
-projects-namespace  0
-```
+|        Name        |      Value       | Type | Count |
+|--------------------|------------------|------|-------|
+| cluster-name       | example-us-east4 | str  |    11 |
+| location           | us-east4         | str  |     1 |
+| max-node-count     |                2 | int  |     1 |
+| nodepool-name      | primary          | str  |    11 |
+| platform-namespace | config-control   | str  |     8 |
+| project-id         | project-id       | str  |     5 |
+| projects-namespace | projects         | str  |     0 |
 
 ## Sub-packages
 
@@ -21,14 +24,13 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File           APIVersion                               Kind               Name                                         Namespace
-node-iam.yaml  iam.cnrm.cloud.google.com/v1beta1        IAMPolicyMember    artifactreader-gke-example-us-east4-primary  config-control
-node-iam.yaml  iam.cnrm.cloud.google.com/v1beta1        IAMPolicyMember    logwriter-gke-example-us-east4-primary       config-control
-node-iam.yaml  iam.cnrm.cloud.google.com/v1beta1        IAMPolicyMember    metricwriter-gke-example-us-east4-primary    config-control
-node-iam.yaml  iam.cnrm.cloud.google.com/v1beta1        IAMServiceAccount  gke-example-us-east4-primary                 config-control
-nodepool.yaml  container.cnrm.cloud.google.com/v1beta1  ContainerNodePool  example-us-east4-primary                     config-control
-```
+|     File      |               APIVersion                |       Kind        |                    Name                     |   Namespace    |
+|---------------|-----------------------------------------|-------------------|---------------------------------------------|----------------|
+| node-iam.yaml | iam.cnrm.cloud.google.com/v1beta1       | IAMServiceAccount | gke-example-us-east4-primary                | config-control |
+| node-iam.yaml | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember   | logwriter-gke-example-us-east4-primary      | config-control |
+| node-iam.yaml | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember   | metricwriter-gke-example-us-east4-primary   | config-control |
+| node-iam.yaml | iam.cnrm.cloud.google.com/v1beta1       | IAMPolicyMember   | artifactreader-gke-example-us-east4-primary | config-control |
+| nodepool.yaml | container.cnrm.cloud.google.com/v1beta1 | ContainerNodePool | example-us-east4-primary                    | config-control |
 
 ## Resource References
 
@@ -39,39 +41,40 @@ nodepool.yaml  container.cnrm.cloud.google.com/v1beta1  ContainerNodePool  examp
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke/nodepools/primary@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke/nodepools/gke-nodepool@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./primary/"
+    ```shell
+    cd "./gke-nodepool/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/gke/nodepools/primary/README.md
+++ b/catalog/gke/nodepools/primary/README.md
@@ -42,14 +42,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke/nodepools/gke-nodepool@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke/nodepools/primary@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./gke-nodepool/"
+    cd "./primary/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/hierarchy/bu/README.md
+++ b/catalog/hierarchy/bu/README.md
@@ -31,14 +31,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/bu-hierarchy@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/bu@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./bu-hierarchy/"
+    cd "./bu/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/hierarchy/bu/README.md
+++ b/catalog/hierarchy/bu/README.md
@@ -19,12 +19,14 @@ This package has no sub-packages.
 
 ## Resources
 
-|      File      |              APIVersion              |       Kind        |      Name      | Namespace |
-|----------------|--------------------------------------|-------------------|----------------|-----------|
-| hierarchy.yaml | blueprints.cloud.google.com/v1alpha3 | ResourceHierarchy | root-hierarchy | hierarchy |
+|              File               |              APIVersion              |        Kind        |         Name         | Namespace |
+|---------------------------------|--------------------------------------|--------------------|----------------------|-----------|
+| hierarchy.yaml                  | blueprints.cloud.google.com/v1alpha3 | ResourceHierarchy  | root-hierarchy       | hierarchy |
+| policies/naming-constraint.yaml | constraints.gatekeeper.sh/v1beta1    | GCPEnforceNamingV2 | enforce-folder-names |           |
 
 ## Resource References
 
+- GCPEnforceNamingV2
 - ResourceHierarchy
 
 ## Usage

--- a/catalog/hierarchy/bu/README.md
+++ b/catalog/hierarchy/bu/README.md
@@ -1,14 +1,17 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Business Unit Hierarchy blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A GCP resource hierarchy organized by business units, teams, and
 environments
 
 ## Setters
 
-```
-Setter     Usages
-namespace  1
-```
+|   Name    |   Value   | Type | Count |
+|-----------|-----------|------|-------|
+| namespace | hierarchy | str  |     1 |
 
 ## Sub-packages
 
@@ -16,53 +19,51 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                             APIVersion                            Kind                Name                  Namespace
-hierarchy.yaml                   blueprints.cloud.google.com/v1alpha3  ResourceHierarchy   root-hierarchy        hierarchy
-policies/naming-constraint.yaml  constraints.gatekeeper.sh/v1beta1     GCPEnforceNamingV2  enforce-folder-names
-```
+|      File      |              APIVersion              |       Kind        |      Name      | Namespace |
+|----------------|--------------------------------------|-------------------|----------------|-----------|
+| hierarchy.yaml | blueprints.cloud.google.com/v1alpha3 | ResourceHierarchy | root-hierarchy | hierarchy |
 
 ## Resource References
 
-- GCPEnforceNamingV2
 - ResourceHierarchy
 
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/bu@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/bu-hierarchy@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./bu/"
+    ```shell
+    cd "./bu-hierarchy/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/hierarchy/env-bu/README.md
+++ b/catalog/hierarchy/env-bu/README.md
@@ -20,14 +20,16 @@ This package has no sub-packages.
 
 ## Resources
 
-|        File         |                  APIVersion                   |       Kind        |      Name      | Namespace |
-|---------------------|-----------------------------------------------|-------------------|----------------|-----------|
-| hierarchy.yaml      | blueprints.cloud.google.com/v1alpha3          | ResourceHierarchy | root-hierarchy | hierarchy |
-| shared-folders.yaml | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder            | dev.shared     | hierarchy |
-| shared-folders.yaml | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder            | prod.shared    | hierarchy |
+|              File               |                  APIVersion                   |        Kind        |         Name         | Namespace |
+|---------------------------------|-----------------------------------------------|--------------------|----------------------|-----------|
+| hierarchy.yaml                  | blueprints.cloud.google.com/v1alpha3          | ResourceHierarchy  | root-hierarchy       | hierarchy |
+| policies/naming-constraint.yaml | constraints.gatekeeper.sh/v1beta1             | GCPEnforceNamingV2 | enforce-folder-names |           |
+| shared-folders.yaml             | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder             | dev.shared           | hierarchy |
+| shared-folders.yaml             | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder             | prod.shared          | hierarchy |
 
 ## Resource References
 
+- GCPEnforceNamingV2
 - ResourceHierarchy
 - [Folder](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/folder)
 

--- a/catalog/hierarchy/env-bu/README.md
+++ b/catalog/hierarchy/env-bu/README.md
@@ -1,14 +1,18 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Environment Business Unit Hierarchy package
 
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A GCP resource hierarchy organized by environments, business units, and
 teams
 
 ## Setters
 
-```
-Setter     Usages
-namespace  3
-```
+|   Name    |   Value   | Type | Count |
+|-----------|-----------|------|-------|
+| namespace | hierarchy | str  |     3 |
 
 ## Sub-packages
 
@@ -16,56 +20,54 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                             APIVersion                                     Kind                Name                  Namespace
-hierarchy.yaml                   blueprints.cloud.google.com/v1alpha3           ResourceHierarchy   root-hierarchy        hierarchy
-policies/naming-constraint.yaml  constraints.gatekeeper.sh/v1beta1              GCPEnforceNamingV2  enforce-folder-names
-shared-folders.yaml              resourcemanager.cnrm.cloud.google.com/v1beta1  Folder              dev.shared            hierarchy
-shared-folders.yaml              resourcemanager.cnrm.cloud.google.com/v1beta1  Folder              prod.shared           hierarchy
-```
+|        File         |                  APIVersion                   |       Kind        |      Name      | Namespace |
+|---------------------|-----------------------------------------------|-------------------|----------------|-----------|
+| hierarchy.yaml      | blueprints.cloud.google.com/v1alpha3          | ResourceHierarchy | root-hierarchy | hierarchy |
+| shared-folders.yaml | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder            | dev.shared     | hierarchy |
+| shared-folders.yaml | resourcemanager.cnrm.cloud.google.com/v1beta1 | Folder            | prod.shared    | hierarchy |
 
 ## Resource References
 
-- [Folder](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/folder)
-- GCPEnforceNamingV2
 - ResourceHierarchy
+- [Folder](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/folder)
 
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/env-bu@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/env-bu-hierarchy@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./env-bu/"
+    ```shell
+    cd "./env-bu-hierarchy/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/hierarchy/env-bu/README.md
+++ b/catalog/hierarchy/env-bu/README.md
@@ -35,14 +35,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/env-bu-hierarchy@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/env-bu@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./env-bu-hierarchy/"
+    cd "./env-bu/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/hierarchy/simple/README.md
+++ b/catalog/hierarchy/simple/README.md
@@ -18,12 +18,14 @@ This package has no sub-packages.
 
 ## Resources
 
-|      File      |              APIVersion              |       Kind        |      Name      | Namespace |
-|----------------|--------------------------------------|-------------------|----------------|-----------|
-| hierarchy.yaml | blueprints.cloud.google.com/v1alpha3 | ResourceHierarchy | root-hierarchy | hierarchy |
+|              File               |              APIVersion              |        Kind        |         Name         | Namespace |
+|---------------------------------|--------------------------------------|--------------------|----------------------|-----------|
+| hierarchy.yaml                  | blueprints.cloud.google.com/v1alpha3 | ResourceHierarchy  | root-hierarchy       | hierarchy |
+| policies/naming-constraint.yaml | constraints.gatekeeper.sh/v1beta1    | GCPEnforceNamingV2 | enforce-folder-names |           |
 
 ## Resource References
 
+- GCPEnforceNamingV2
 - ResourceHierarchy
 
 ## Usage

--- a/catalog/hierarchy/simple/README.md
+++ b/catalog/hierarchy/simple/README.md
@@ -1,13 +1,16 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Simple Hierarchy blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A simple GCP resource hierarchy with top-level folders
 
 ## Setters
 
-```
-Setter     Usages
-namespace  1
-```
+|   Name    |   Value   | Type | Count |
+|-----------|-----------|------|-------|
+| namespace | hierarchy | str  |     1 |
 
 ## Sub-packages
 
@@ -15,53 +18,51 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                             APIVersion                            Kind                Name                  Namespace
-hierarchy.yaml                   blueprints.cloud.google.com/v1alpha3  ResourceHierarchy   root-hierarchy        hierarchy
-policies/naming-constraint.yaml  constraints.gatekeeper.sh/v1beta1     GCPEnforceNamingV2  enforce-folder-names
-```
+|      File      |              APIVersion              |       Kind        |      Name      | Namespace |
+|----------------|--------------------------------------|-------------------|----------------|-----------|
+| hierarchy.yaml | blueprints.cloud.google.com/v1alpha3 | ResourceHierarchy | root-hierarchy | hierarchy |
 
 ## Resource References
 
-- GCPEnforceNamingV2
 - ResourceHierarchy
 
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/simple@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/simple-hierarchy@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./simple/"
+    ```shell
+    cd "./simple-hierarchy/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/hierarchy/simple/README.md
+++ b/catalog/hierarchy/simple/README.md
@@ -30,14 +30,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/simple-hierarchy@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/simple@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./simple-hierarchy/"
+    cd "./simple/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/hierarchy/team/README.md
+++ b/catalog/hierarchy/team/README.md
@@ -18,12 +18,14 @@ This package has no sub-packages.
 
 ## Resources
 
-|      File      |              APIVersion              |       Kind        |      Name      | Namespace |
-|----------------|--------------------------------------|-------------------|----------------|-----------|
-| hierarchy.yaml | blueprints.cloud.google.com/v1alpha3 | ResourceHierarchy | root-hierarchy | hierarchy |
+|              File               |              APIVersion              |        Kind        |         Name         | Namespace |
+|---------------------------------|--------------------------------------|--------------------|----------------------|-----------|
+| hierarchy.yaml                  | blueprints.cloud.google.com/v1alpha3 | ResourceHierarchy  | root-hierarchy       | hierarchy |
+| policies/naming-constraint.yaml | constraints.gatekeeper.sh/v1beta1    | GCPEnforceNamingV2 | enforce-folder-names |           |
 
 ## Resource References
 
+- GCPEnforceNamingV2
 - ResourceHierarchy
 
 ## Usage

--- a/catalog/hierarchy/team/README.md
+++ b/catalog/hierarchy/team/README.md
@@ -1,13 +1,16 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Team Hierarchy blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A GCP resource hierarchy organized by teams and environments
 
 ## Setters
 
-```
-Setter     Usages
-namespace  1
-```
+|   Name    |   Value   | Type | Count |
+|-----------|-----------|------|-------|
+| namespace | hierarchy | str  |     1 |
 
 ## Sub-packages
 
@@ -15,53 +18,51 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                             APIVersion                            Kind                Name                  Namespace
-hierarchy.yaml                   blueprints.cloud.google.com/v1alpha3  ResourceHierarchy   root-hierarchy        hierarchy
-policies/naming-constraint.yaml  constraints.gatekeeper.sh/v1beta1     GCPEnforceNamingV2  enforce-folder-names
-```
+|      File      |              APIVersion              |       Kind        |      Name      | Namespace |
+|----------------|--------------------------------------|-------------------|----------------|-----------|
+| hierarchy.yaml | blueprints.cloud.google.com/v1alpha3 | ResourceHierarchy | root-hierarchy | hierarchy |
 
 ## Resource References
 
-- GCPEnforceNamingV2
 - ResourceHierarchy
 
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/team@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/team-hierarchy@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./team/"
+    ```shell
+    cd "./team-hierarchy/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/hierarchy/team/README.md
+++ b/catalog/hierarchy/team/README.md
@@ -30,14 +30,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/team-hierarchy@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/hierarchy/team@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./team-hierarchy/"
+    cd "./team/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/iam-foundation/README.md
+++ b/catalog/iam-foundation/README.md
@@ -1,17 +1,20 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Organizational Foundational IAM
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 This blueprint sets up recommended IAM roles for an enterprise organization in Google Cloud.
 
 ## Setters
 
-```
-Setter                 Usages
-group-devops           1
-group-network-admins   4
-group-org-admins       1
-group-security-admins  10
-org-id                 16
-```
+|         Name          |                Value                | Type | Count |
+|-----------------------|-------------------------------------|------|-------|
+| group-devops          | gcp-devops@example.com              | str  |     1 |
+| group-network-admins  | gcp-network-admins@example.com      | str  |     4 |
+| group-org-admins      | gcp-organization-admins@example.com | str  |     1 |
+| group-security-admins | gcp-security-admins@example.com     | str  |    10 |
+| org-id                |                        123456789012 | str  |    16 |
 
 ## Sub-packages
 
@@ -19,25 +22,24 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File             APIVersion                         Kind             Name                               Namespace
-devops.yaml      iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  foundation-devops-folders          config-control
-networking.yaml  iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  network-admins-compute             config-control
-networking.yaml  iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  network-admins-folders             config-control
-networking.yaml  iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  network-admins-security            config-control
-networking.yaml  iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  network-admins-shared-vpc          config-control
-org.yaml         iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  foundation-org-admin               config-control
-security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-bq                 config-control
-security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-custom-roles       config-control
-security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-folder-iam         config-control
-security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-gce                config-control
-security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-gke                config-control
-security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-log-config         config-control
-security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-org-policy         config-control
-security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-private-logs       config-control
-security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-scc                config-control
-security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-admins-security-reviewer  config-control
-```
+|      File       |            APIVersion             |      Kind       |               Name                |   Namespace    |
+|-----------------|-----------------------------------|-----------------|-----------------------------------|----------------|
+| devops.yaml     | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | foundation-devops-folders         | config-control |
+| networking.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | network-admins-compute            | config-control |
+| networking.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | network-admins-shared-vpc         | config-control |
+| networking.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | network-admins-security           | config-control |
+| networking.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | network-admins-folders            | config-control |
+| org.yaml        | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | foundation-org-admin              | config-control |
+| security.yaml   | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | security-admins-org-policy        | config-control |
+| security.yaml   | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | security-admins-security-reviewer | config-control |
+| security.yaml   | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | security-admins-custom-roles      | config-control |
+| security.yaml   | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | security-admins-scc               | config-control |
+| security.yaml   | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | security-admins-folder-iam        | config-control |
+| security.yaml   | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | security-admins-private-logs      | config-control |
+| security.yaml   | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | security-admins-log-config        | config-control |
+| security.yaml   | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | security-admins-gke               | config-control |
+| security.yaml   | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | security-admins-gce               | config-control |
+| security.yaml   | iam.cnrm.cloud.google.com/v1beta1 | IAMPolicyMember | security-admins-bq                | config-control |
 
 ## Resource References
 
@@ -46,14 +48,14 @@ security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-ad
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/iam-foundation@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./iam-foundation/"
     ```
 
@@ -61,24 +63,25 @@ security.yaml    iam.cnrm.cloud.google.com/v1beta1  IAMPolicyMember  security-ad
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/landing-zone-lite/README.md
+++ b/catalog/landing-zone-lite/README.md
@@ -29,16 +29,37 @@ This package has no sub-packages.
 
 ## Resources
 
-|     File      |              APIVersion              |       Kind        |         Name          |   Namespace    |
-|---------------|--------------------------------------|-------------------|-----------------------|----------------|
-| iam.yaml      | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember   | org-admins-iam        | config-control |
-| iam.yaml      | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember   | billing-admins-iam    | config-control |
-| services.yaml | blueprints.cloud.google.com/v1alpha1 | ProjectServiceSet | management-project-id | config-control |
+|           File            |              APIVersion              |          Kind          |                       Name                        |   Namespace    |
+|---------------------------|--------------------------------------|------------------------|---------------------------------------------------|----------------|
+| iam.yaml                  | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | org-admins-iam                                    | config-control |
+| iam.yaml                  | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | billing-admins-iam                                | config-control |
+| namespaces/hierarchy.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | hierarchy-sa                                      | config-control |
+| namespaces/hierarchy.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | hierarchy-sa-folderadmin-permissions              | config-control |
+| namespaces/hierarchy.yaml | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | hierarchy-sa-workload-identity-binding            | config-control |
+| namespaces/hierarchy.yaml | rbac.authorization.k8s.io/v1         | RoleBinding            | allow-resource-reference-from-hierarchy           | hierarchy      |
+| namespaces/hierarchy.yaml | v1                                   | Namespace              | hierarchy                                         |                |
+| namespaces/hierarchy.yaml | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | hierarchy      |
+| namespaces/projects.yaml  | iam.cnrm.cloud.google.com/v1beta1    | IAMServiceAccount      | projects-sa                                       | config-control |
+| namespaces/projects.yaml  | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectiamadmin-permissions           | config-control |
+| namespaces/projects.yaml  | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectcreator-permissions            | config-control |
+| namespaces/projects.yaml  | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectmover-permissions              | config-control |
+| namespaces/projects.yaml  | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-projectdeleter-permissions            | config-control |
+| namespaces/projects.yaml  | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-billinguser-permissions               | config-control |
+| namespaces/projects.yaml  | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember        | projects-sa-serviceusageadmin-permissions         | config-control |
+| namespaces/projects.yaml  | iam.cnrm.cloud.google.com/v1beta1    | IAMPartialPolicy       | projects-sa-workload-identity-binding             | config-control |
+| namespaces/projects.yaml  | v1                                   | Namespace              | projects                                          |                |
+| namespaces/projects.yaml  | core.cnrm.cloud.google.com/v1beta1   | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | projects       |
+| services.yaml             | blueprints.cloud.google.com/v1alpha1 | ProjectServiceSet      | management-project-id                             | config-control |
 
 ## Resource References
 
 - ProjectServiceSet
+- [ConfigConnectorContext](https://cloud.google.com/config-connector/docs/how-to/advanced-install#addon-configuring)
+- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
 - [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)
+- [Namespace](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#namespace-v1-core)
+- [RoleBinding](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#rolebinding-v1-rbac-authorization-k8s-io)
 
 ## Usage
 

--- a/catalog/landing-zone-lite/README.md
+++ b/catalog/landing-zone-lite/README.md
@@ -1,6 +1,11 @@
-# Landing Zone blueprint
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# Landing Zone Lite blueprint
 
-Foundational landing zone blueprint for GCP.
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+Foundational landing zone blueprint for GCP for creating only a resource
+hierarchy and projects.
 
 This blueprint configures organization level IAM permissions.
 
@@ -9,15 +14,14 @@ For a full tutorial, see
 
 ## Setters
 
-```
-Setter                 Usages
-billing-account-id     0
-group-billing-admins   1
-group-org-admins       1
-management-namespace   15
-management-project-id  26
-org-id                 2
-```
+|         Name          |                Value                | Type | Count |
+|-----------------------|-------------------------------------|------|-------|
+| billing-account-id    | AAAAAA-BBBBBB-CCCCCC                | str  |     0 |
+| group-billing-admins  | gcp-billing-admins@example.com      | str  |     1 |
+| group-org-admins      | gcp-organization-admins@example.com | str  |     1 |
+| management-namespace  | config-control                      | str  |    14 |
+| management-project-id | management-project-id               | str  |    24 |
+| org-id                |                        123456789012 | str  |    11 |
 
 ## Sub-packages
 
@@ -25,53 +29,28 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                                             APIVersion                                     Kind                    Name                                               Namespace
-iam.yaml                                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         billing-admins-iam                                 config-control
-iam.yaml                                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         org-admins-iam                                     config-control
-namespaces/hierarchy.yaml                        core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  hierarchy
-namespaces/hierarchy.yaml                        iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         hierarchy-sa-folderadmin-permissions               config-control
-namespaces/hierarchy.yaml                        iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         hierarchy-sa-workload-identity-binding             config-control
-namespaces/hierarchy.yaml                        iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       hierarchy-sa                                       config-control
-namespaces/hierarchy.yaml                        rbac.authorization.k8s.io/v1                   RoleBinding             allow-resource-reference-from-hierarchy            hierarchy
-namespaces/hierarchy.yaml                        v1                                             Namespace               hierarchy
-namespaces/projects.yaml                         core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  projects
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-billinguser-permissions                config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-projectiamadmin-permissions            config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-projectcreator-permissions             config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-projectdeleter-permissions             config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-projectmover-permissions               config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-serviceusageadmin-permissions          config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-workload-identity-binding              config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       projects-sa                                        config-control
-namespaces/projects.yaml                         v1                                             Namespace               projects
-services.yaml                                    serviceusage.cnrm.cloud.google.com/v1beta1     Service                 management-project-id-cloudbilling                 config-control
-services.yaml                                    serviceusage.cnrm.cloud.google.com/v1beta1     Service                 management-project-id-resourcemanager              config-control
-services.yaml                                    serviceusage.cnrm.cloud.google.com/v1beta1     Service                 management-project-id-serviceusage                 config-control
-```
+|     File      |              APIVersion              |       Kind        |         Name          |   Namespace    |
+|---------------|--------------------------------------|-------------------|-----------------------|----------------|
+| iam.yaml      | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember   | org-admins-iam        | config-control |
+| iam.yaml      | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember   | billing-admins-iam    | config-control |
+| services.yaml | blueprints.cloud.google.com/v1alpha1 | ProjectServiceSet | management-project-id | config-control |
 
 ## Resource References
 
-- [ConfigConnectorContext](https://cloud.google.com/config-connector/docs/how-to/advanced-install#addon-configuring)
-- ConstraintTemplate
-- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
-- [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)
-- [Namespace](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#namespace-v1-core)
-- [ResourceManagerPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/resourcemanagerpolicy)
-- [RoleBinding](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#rolebinding-v1-rbac-authorization-k8s-io)
-- [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
+- ProjectServiceSet
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
 
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/landing-zone-lite@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./landing-zone-lite/"
     ```
 
@@ -79,23 +58,25 @@ services.yaml                                    serviceusage.cnrm.cloud.google.
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/landing-zone/README.md
+++ b/catalog/landing-zone/README.md
@@ -28,16 +28,73 @@ This package has no sub-packages.
 
 ## Resources
 
-|     File      |              APIVersion              |       Kind        |         Name          |   Namespace    |
-|---------------|--------------------------------------|-------------------|-----------------------|----------------|
-| iam.yaml      | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember   | org-admins-iam        | config-control |
-| iam.yaml      | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember   | billing-admins-iam    | config-control |
-| services.yaml | blueprints.cloud.google.com/v1alpha1 | ProjectServiceSet | management-project-id | config-control |
+|                      File                       |                  APIVersion                   |          Kind          |                       Name                        |   Namespace    |
+|-------------------------------------------------|-----------------------------------------------|------------------------|---------------------------------------------------|----------------|
+| iam.yaml                                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | org-admins-iam                                    | config-control |
+| iam.yaml                                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | billing-admins-iam                                | config-control |
+| namespaces/hierarchy.yaml                       | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount      | hierarchy-sa                                      | config-control |
+| namespaces/hierarchy.yaml                       | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | hierarchy-sa-folderadmin-permissions              | config-control |
+| namespaces/hierarchy.yaml                       | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | hierarchy-sa-workload-identity-binding            | config-control |
+| namespaces/hierarchy.yaml                       | rbac.authorization.k8s.io/v1                  | RoleBinding            | allow-resource-reference-from-hierarchy           | hierarchy      |
+| namespaces/hierarchy.yaml                       | v1                                            | Namespace              | hierarchy                                         |                |
+| namespaces/hierarchy.yaml                       | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | hierarchy      |
+| namespaces/logging.yaml                         | v1                                            | Namespace              | logging                                           |                |
+| namespaces/logging.yaml                         | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | logging        |
+| namespaces/logging.yaml                         | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount      | logging-sa                                        | config-control |
+| namespaces/logging.yaml                         | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | logging-sa-logadmin-permissions                   | config-control |
+| namespaces/logging.yaml                         | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | logging-sa-bigqueryadmin-permissions              | config-control |
+| namespaces/logging.yaml                         | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | logging-sa-workload-identity-binding              | config-control |
+| namespaces/logging.yaml                         | rbac.authorization.k8s.io/v1                  | RoleBinding            | allow-resource-reference-from-logging             | projects       |
+| namespaces/networking.yaml                      | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount      | networking-sa                                     | config-control |
+| namespaces/networking.yaml                      | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | networking-sa-networkadmin-permissions            | config-control |
+| namespaces/networking.yaml                      | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | networking-sa-security-permissions                | config-control |
+| namespaces/networking.yaml                      | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | networking-sa-dns-permissions                     | config-control |
+| namespaces/networking.yaml                      | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | networking-sa-service-control-permissions         | config-control |
+| namespaces/networking.yaml                      | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | networking-sa-xpnadmin-permissions                | config-control |
+| namespaces/networking.yaml                      | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | networking-sa-workload-identity-binding           | config-control |
+| namespaces/networking.yaml                      | v1                                            | Namespace              | networking                                        |                |
+| namespaces/networking.yaml                      | rbac.authorization.k8s.io/v1                  | RoleBinding            | allow-resource-reference-from-networking          | projects       |
+| namespaces/networking.yaml                      | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | networking     |
+| namespaces/policies.yaml                        | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount      | policies-sa                                       | config-control |
+| namespaces/policies.yaml                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | policies-sa-orgpolicyadmin-permissions            | config-control |
+| namespaces/policies.yaml                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | policies-sa-workload-identity-binding             | config-control |
+| namespaces/policies.yaml                        | v1                                            | Namespace              | policies                                          |                |
+| namespaces/policies.yaml                        | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | policies       |
+| namespaces/projects.yaml                        | iam.cnrm.cloud.google.com/v1beta1             | IAMServiceAccount      | projects-sa                                       | config-control |
+| namespaces/projects.yaml                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | projects-sa-projectiamadmin-permissions           | config-control |
+| namespaces/projects.yaml                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | projects-sa-projectcreator-permissions            | config-control |
+| namespaces/projects.yaml                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | projects-sa-projectmover-permissions              | config-control |
+| namespaces/projects.yaml                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | projects-sa-projectdeleter-permissions            | config-control |
+| namespaces/projects.yaml                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | projects-sa-billinguser-permissions               | config-control |
+| namespaces/projects.yaml                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPolicyMember        | projects-sa-serviceusageadmin-permissions         | config-control |
+| namespaces/projects.yaml                        | iam.cnrm.cloud.google.com/v1beta1             | IAMPartialPolicy       | projects-sa-workload-identity-binding             | config-control |
+| namespaces/projects.yaml                        | v1                                            | Namespace              | projects                                          |                |
+| namespaces/projects.yaml                        | core.cnrm.cloud.google.com/v1beta1            | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | projects       |
+| policies/deletion-policy-required-template.yaml | templates.gatekeeper.sh/v1beta1               | ConstraintTemplate     | gcprequiredeletionpolicy                          |                |
+| policies/disable-guest-attributes.yaml          | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | disable-guest-attributes                          | policies       |
+| policies/disable-iam-grants-default-sa.yaml     | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | disable-iam-grants-default-sa                     | policies       |
+| policies/disable-nested-virtualization.yaml     | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | disable-nested-virtualization                     | policies       |
+| policies/disable-sa-key-creation.yaml           | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | disable-sa-key-creation                           | policies       |
+| policies/disable-serial-port.yaml               | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | disable-serial-port                               | policies       |
+| policies/disable-vm-external-ip.yaml            | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | disable-vm-external-ip                            | policies       |
+| policies/enforce-uniform-bucket-lvl-access.yaml | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | enforce-uniform-bucket-lvl-access                 | policies       |
+| policies/folder-naming-constraint-template.yaml | templates.gatekeeper.sh/v1beta1               | ConstraintTemplate     | gcpenforcenamingv2                                |                |
+| policies/restrict-cloud-sql-public-ip.yaml      | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | restrict-cloud-sql-public-ip                      | policies       |
+| policies/restrict-lien-removal.yaml             | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | restrict-lien-removal                             | policies       |
+| policies/skip-default-network.yaml              | resourcemanager.cnrm.cloud.google.com/v1beta1 | ResourceManagerPolicy  | skip-default-network                              | policies       |
+| services.yaml                                   | blueprints.cloud.google.com/v1alpha1          | ProjectServiceSet      | management-project-id                             | config-control |
 
 ## Resource References
 
+- ConstraintTemplate
 - ProjectServiceSet
+- [ConfigConnectorContext](https://cloud.google.com/config-connector/docs/how-to/advanced-install#addon-configuring)
+- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
 - [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
+- [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)
+- [Namespace](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#namespace-v1-core)
+- [ResourceManagerPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/resourcemanagerpolicy)
+- [RoleBinding](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#rolebinding-v1-rbac-authorization-k8s-io)
 
 ## Usage
 

--- a/catalog/landing-zone/README.md
+++ b/catalog/landing-zone/README.md
@@ -1,5 +1,9 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Landing Zone blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 Foundational landing zone blueprint for GCP.
 
 This blueprint configures organization level IAM permissions.
@@ -9,15 +13,14 @@ For a full tutorial, see
 
 ## Setters
 
-```
-Setter                 Usages
-billing-account-id     0
-group-billing-admins   1
-group-org-admins       1
-management-namespace   27
-management-project-id  50
-org-id                 31
-```
+|         Name          |                Value                | Type | Count |
+|-----------------------|-------------------------------------|------|-------|
+| billing-account-id    | AAAAAA-BBBBBB-CCCCCC                | str  |     0 |
+| group-billing-admins  | gcp-billing-admins@example.com      | str  |     1 |
+| group-org-admins      | gcp-organization-admins@example.com | str  |     1 |
+| management-namespace  | config-control                      | str  |    28 |
+| management-project-id | management-project-id               | str  |    52 |
+| org-id                |                        123456789012 | str  |    32 |
 
 ## Sub-packages
 
@@ -25,87 +28,28 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                                             APIVersion                                     Kind                    Name                                               Namespace
-iam.yaml                                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         billing-admins-iam                                 config-control
-iam.yaml                                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         org-admins-iam                                     config-control
-namespaces/hierarchy.yaml                        core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  hierarchy
-namespaces/hierarchy.yaml                        iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         hierarchy-sa-folderadmin-permissions               config-control
-namespaces/hierarchy.yaml                        iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         hierarchy-sa-workload-identity-binding             config-control
-namespaces/hierarchy.yaml                        iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       hierarchy-sa                                       config-control
-namespaces/hierarchy.yaml                        rbac.authorization.k8s.io/v1                   RoleBinding             allow-resource-reference-from-hierarchy            hierarchy
-namespaces/hierarchy.yaml                        v1                                             Namespace               hierarchy
-namespaces/logging.yaml                          core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  logging
-namespaces/logging.yaml                          iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         logging-sa-bigqueryadmin-permissions               config-control
-namespaces/logging.yaml                          iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         logging-sa-logadmin-permissions                    config-control
-namespaces/logging.yaml                          iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         logging-sa-workload-identity-binding               config-control
-namespaces/logging.yaml                          iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       logging-sa                                         config-control
-namespaces/logging.yaml                          rbac.authorization.k8s.io/v1                   RoleBinding             allow-resource-reference-from-logging              projects
-namespaces/logging.yaml                          v1                                             Namespace               logging
-namespaces/networking.yaml                       core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  networking
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-dns-permissions                      config-control
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-networkadmin-permissions             config-control
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-security-permissions                 config-control
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-service-control-permissions          config-control
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-workload-identity-binding            config-control
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         networking-sa-xpnadmin-permissions                 config-control
-namespaces/networking.yaml                       iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       networking-sa                                      config-control
-namespaces/networking.yaml                       rbac.authorization.k8s.io/v1                   RoleBinding             allow-resource-reference-from-networking           projects
-namespaces/networking.yaml                       v1                                             Namespace               networking
-namespaces/policies.yaml                         core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  policies
-namespaces/policies.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         policies-sa-orgpolicyadmin-permissions             config-control
-namespaces/policies.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         policies-sa-workload-identity-binding              config-control
-namespaces/policies.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       policies-sa                                        config-control
-namespaces/policies.yaml                         v1                                             Namespace               policies
-namespaces/projects.yaml                         core.cnrm.cloud.google.com/v1beta1             ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  projects
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-projectiamadmin-permissions            config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-billinguser-permissions                config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-projectcreator-permissions             config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-projectdeleter-permissions             config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-projectmover-permissions               config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-serviceusageadmin-permissions          config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMPartialPolicy         projects-sa-workload-identity-binding              config-control
-namespaces/projects.yaml                         iam.cnrm.cloud.google.com/v1beta1              IAMServiceAccount       projects-sa                                        config-control
-namespaces/projects.yaml                         v1                                             Namespace               projects
-policies/deletion-policy-required-template.yaml  templates.gatekeeper.sh/v1beta1                ConstraintTemplate      gcprequiredeletionpolicy
-policies/disable-guest-attributes.yaml           resourcemanager.cnrm.cloud.google.com/v1beta1  ResourceManagerPolicy   disable-guest-attributes                           policies
-policies/disable-iam-grants-default-sa.yaml      resourcemanager.cnrm.cloud.google.com/v1beta1  ResourceManagerPolicy   disable-iam-grants-default-sa                      policies
-policies/disable-nested-virtualization.yaml      resourcemanager.cnrm.cloud.google.com/v1beta1  ResourceManagerPolicy   disable-nested-virtualization                      policies
-policies/disable-sa-key-creation.yaml            resourcemanager.cnrm.cloud.google.com/v1beta1  ResourceManagerPolicy   disable-sa-key-creation                            policies
-policies/disable-serial-port.yaml                resourcemanager.cnrm.cloud.google.com/v1beta1  ResourceManagerPolicy   disable-serial-port                                policies
-policies/disable-vm-external-ip.yaml             resourcemanager.cnrm.cloud.google.com/v1beta1  ResourceManagerPolicy   disable-vm-external-ip                             policies
-policies/enforce-uniform-bucket-lvl-access.yaml  resourcemanager.cnrm.cloud.google.com/v1beta1  ResourceManagerPolicy   enforce-uniform-bucket-lvl-access                  policies
-policies/folder-naming-constraint-template.yaml  templates.gatekeeper.sh/v1beta1                ConstraintTemplate      gcpenforcenamingv2
-policies/restrict-cloud-sql-public-ip.yaml       resourcemanager.cnrm.cloud.google.com/v1beta1  ResourceManagerPolicy   restrict-cloud-sql-public-ip                       policies
-policies/restrict-lien-removal.yaml              resourcemanager.cnrm.cloud.google.com/v1beta1  ResourceManagerPolicy   restrict-lien-removal                              policies
-policies/skip-default-network.yaml               resourcemanager.cnrm.cloud.google.com/v1beta1  ResourceManagerPolicy   skip-default-network                               policies
-services.yaml                                    serviceusage.cnrm.cloud.google.com/v1beta1     Service                 management-project-id-cloudbilling                 config-control
-services.yaml                                    serviceusage.cnrm.cloud.google.com/v1beta1     Service                 management-project-id-resourcemanager              config-control
-services.yaml                                    serviceusage.cnrm.cloud.google.com/v1beta1     Service                 management-project-id-serviceusage                 config-control
-```
+|     File      |              APIVersion              |       Kind        |         Name          |   Namespace    |
+|---------------|--------------------------------------|-------------------|-----------------------|----------------|
+| iam.yaml      | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember   | org-admins-iam        | config-control |
+| iam.yaml      | iam.cnrm.cloud.google.com/v1beta1    | IAMPolicyMember   | billing-admins-iam    | config-control |
+| services.yaml | blueprints.cloud.google.com/v1alpha1 | ProjectServiceSet | management-project-id | config-control |
 
 ## Resource References
 
-- [ConfigConnectorContext](https://cloud.google.com/config-connector/docs/how-to/advanced-install#addon-configuring)
-- ConstraintTemplate
-- [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
-- [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)
-- [Namespace](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#namespace-v1-core)
-- [ResourceManagerPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/resourcemanager/resourcemanagerpolicy)
-- [RoleBinding](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#rolebinding-v1-rbac-authorization-k8s-io)
-- [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
+- ProjectServiceSet
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
 
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/landing-zone@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./landing-zone/"
     ```
 
@@ -113,23 +57,25 @@ services.yaml                                    serviceusage.cnrm.cloud.google.
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/log-export/folder/bigquery-export/README.md
+++ b/catalog/log-export/folder/bigquery-export/README.md
@@ -1,21 +1,24 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # BigQuery Export blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A log export on a folder that sinks to BigQuery
 
 ## Setters
 
-```
-Setter                       Usages
-dataset-description          1
-dataset-location             1
-dataset-name                 1
-default-table-expiration-ms  1
-delete-contents-on-destroy   1
-filter                       1
-folder-k8s-name              3
-namespace                    3
-project-id                   3
-```
+|            Name             |             Value              | Type | Count |
+|-----------------------------|--------------------------------|------|-------|
+| dataset-description         | BigQuery audit logs for folder | str  |     1 |
+| dataset-location            | US                             | str  |     1 |
+| dataset-name                | audit-logs                     | str  |     1 |
+| default-table-expiration-ms |                        3600000 | int  |     1 |
+| delete-contents-on-destroy  | false                          | str  |     1 |
+| filter                      |                                | str  |     0 |
+| folder-k8s-name             | my.folder.k8s.name             | str  |     3 |
+| namespace                   | my-namespace                   | str  |     3 |
+| project-id                  | my-project-id                  | str  |     3 |
 
 ## Sub-packages
 
@@ -23,13 +26,12 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File         APIVersion                                  Kind             Name                       Namespace
-export.yaml  bigquery.cnrm.cloud.google.com/v1beta1      BigQueryDataset  bqlogexportdataset         my-namespace
-export.yaml  logging.cnrm.cloud.google.com/v1beta1       LoggingLogSink   my.folder.k8s.name-bqsink  my-namespace
-export.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service          my-project-id-bigquery     projects
-iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  bq-project-iam-policy      my-namespace
-```
+|    File     |                 APIVersion                 |      Kind       |           Name            |  Namespace   |
+|-------------|--------------------------------------------|-----------------|---------------------------|--------------|
+| export.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service         | my-project-id-bigquery    | projects     |
+| export.yaml | logging.cnrm.cloud.google.com/v1beta1      | LoggingLogSink  | my.folder.k8s.name-bqsink | my-namespace |
+| export.yaml | bigquery.cnrm.cloud.google.com/v1beta1     | BigQueryDataset | bqlogexportdataset        | my-namespace |
+| iam.yaml    | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember | bq-project-iam-policy     | my-namespace |
 
 ## Resource References
 
@@ -41,14 +43,14 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  bq-pro
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/log-export/folder/bigquery-export@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./bigquery-export/"
     ```
 
@@ -56,24 +58,25 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  bq-pro
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/log-export/folder/pubsub-export/README.md
+++ b/catalog/log-export/folder/pubsub-export/README.md
@@ -1,17 +1,20 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # PubSub Export blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A log export on a folder that sinks to PubSub
 
 ## Setters
 
-```
-Setter           Usages
-filter           1
-folder-k8s-name  3
-namespace        3
-project-id       2
-topic-name       3
-```
+|      Name       |          Value           | Type | Count |
+|-----------------|--------------------------|------|-------|
+| filter          |                          | str  |     0 |
+| folder-k8s-name | my.folder.k8s.name       | str  |     3 |
+| namespace       | my-namespace             | str  |     3 |
+| project-id      | my-project-id            | str  |     2 |
+| topic-name      | pubsub-logexport-dataset | str  |     3 |
 
 ## Sub-packages
 
@@ -19,13 +22,12 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File         APIVersion                                  Kind             Name                           Namespace
-export.yaml  logging.cnrm.cloud.google.com/v1beta1       LoggingLogSink   my.folder.k8s.name-pubsubsink  my-namespace
-export.yaml  pubsub.cnrm.cloud.google.com/v1beta1        PubSubTopic      pubsub-logexport-dataset       my-namespace
-export.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service          my-project-id-pubsub           projects
-iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  pubsub-iam-policy              my-namespace
-```
+|    File     |                 APIVersion                 |      Kind       |             Name              |  Namespace   |
+|-------------|--------------------------------------------|-----------------|-------------------------------|--------------|
+| export.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service         | my-project-id-pubsub          | projects     |
+| export.yaml | logging.cnrm.cloud.google.com/v1beta1      | LoggingLogSink  | my.folder.k8s.name-pubsubsink | my-namespace |
+| export.yaml | pubsub.cnrm.cloud.google.com/v1beta1       | PubSubTopic     | pubsub-logexport-dataset      | my-namespace |
+| iam.yaml    | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember | pubsub-iam-policy             | my-namespace |
 
 ## Resource References
 
@@ -37,14 +39,14 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  pubsub
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/log-export/folder/pubsub-export@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./pubsub-export/"
     ```
 
@@ -52,24 +54,25 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  pubsub
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/log-export/folder/storage-export/README.md
+++ b/catalog/log-export/folder/storage-export/README.md
@@ -1,20 +1,23 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Cloud Storage Export blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A log export on a folder that sinks to Cloud Storage
 
 ## Setters
 
-```
-Setter               Usages
-bucket-policy-only   1
-filter               1
-folder-k8s-name      3
-location             1
-namespace            3
-project-id           2
-storage-bucket-name  3
-storage-class        1
-```
+|        Name         |       Value        | Type | Count |
+|---------------------|--------------------|------|-------|
+| bucket-policy-only  | false              | bool |     1 |
+| filter              |                    | str  |     0 |
+| folder-k8s-name     | my.folder.k8s.name | str  |     3 |
+| location            | US                 | str  |     1 |
+| namespace           | my-namespace       | str  |     3 |
+| project-id          | my-project-id      | str  |     2 |
+| storage-bucket-name | my-storage-bucket  | str  |     3 |
+| storage-class       | MULTI_REGIONAL     | str  |     1 |
 
 ## Sub-packages
 
@@ -22,13 +25,12 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File         APIVersion                                  Kind             Name                            Namespace
-export.yaml  logging.cnrm.cloud.google.com/v1beta1       LoggingLogSink   my.folder.k8s.name-storagesink  my-namespace
-export.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service          my-project-id-storage           projects
-export.yaml  storage.cnrm.cloud.google.com/v1beta1       StorageBucket    my-storage-bucket               my-namespace
-iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  storage-project-iam-policy      my-namespace
-```
+|    File     |                 APIVersion                 |      Kind       |              Name              |  Namespace   |
+|-------------|--------------------------------------------|-----------------|--------------------------------|--------------|
+| export.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service         | my-project-id-storage          | projects     |
+| export.yaml | logging.cnrm.cloud.google.com/v1beta1      | LoggingLogSink  | my.folder.k8s.name-storagesink | my-namespace |
+| export.yaml | storage.cnrm.cloud.google.com/v1beta1      | StorageBucket   | my-storage-bucket              | my-namespace |
+| iam.yaml    | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember | storage-project-iam-policy     | my-namespace |
 
 ## Resource References
 
@@ -40,14 +42,14 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  storag
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/log-export/folder/storage-export@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./storage-export/"
     ```
 
@@ -55,24 +57,25 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  storag
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/log-export/org/bigquery-export/README.md
+++ b/catalog/log-export/org/bigquery-export/README.md
@@ -1,23 +1,26 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # BigQuery Export blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A log export on a organization that sinks to BigQuery
 
 ## Setters
 
-```
-Setter                       Usages
-dataset-description          1
-dataset-location             1
-dataset-name                 1
-default-table-expiration-ms  1
-delete-contents-on-destroy   1
-filter                       1
-management-namespace         1
-management-project-id        1
-namespace                    3
-org-id                       3
-project-id                   5
-```
+|            Name             |                Value                 | Type | Count |
+|-----------------------------|--------------------------------------|------|-------|
+| dataset-description         | BigQuery audit logs for organization | str  |     1 |
+| dataset-location            | US                                   | str  |     1 |
+| dataset-name                | audit-logs                           | str  |     1 |
+| default-table-expiration-ms |                              3600000 | int  |     1 |
+| delete-contents-on-destroy  | false                                | str  |     1 |
+| filter                      |                                      | str  |     0 |
+| management-namespace        | config-control                       | str  |     1 |
+| management-project-id       | management-project-id                | str  |     1 |
+| namespace                   | logging                              | str  |     3 |
+| org-id                      |                         123456789012 | str  |     3 |
+| project-id                  | my-project-id                        | str  |     5 |
 
 ## Sub-packages
 
@@ -25,34 +28,33 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File         APIVersion                                  Kind             Name                        Namespace
-export.yaml  bigquery.cnrm.cloud.google.com/v1beta1      BigQueryDataset  bqlogexportdataset          logging
-export.yaml  logging.cnrm.cloud.google.com/v1beta1       LoggingLogSink   123456789012-bqsink         logging
-export.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service          my-project-id-bigquery      projects
-iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  bq-project-iam-policy       logging
-iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPartialPolicy  logging-sa-iam-permissions  config-control
-```
+|    File     |                 APIVersion                 |       Kind       |            Name            |   Namespace    |
+|-------------|--------------------------------------------|------------------|----------------------------|----------------|
+| export.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service          | my-project-id-bigquery     | projects       |
+| export.yaml | logging.cnrm.cloud.google.com/v1beta1      | LoggingLogSink   | 123456789012-bqsink        | logging        |
+| export.yaml | bigquery.cnrm.cloud.google.com/v1beta1     | BigQueryDataset  | bqlogexportdataset         | logging        |
+| iam.yaml    | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember  | bq-project-iam-policy      | logging        |
+| iam.yaml    | iam.cnrm.cloud.google.com/v1beta1          | IAMPartialPolicy | logging-sa-iam-permissions | config-control |
 
 ## Resource References
 
 - [BigQueryDataset](https://cloud.google.com/config-connector/docs/reference/resource-docs/bigquery/bigquerydataset)
-- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
 - [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
+- [IAMPolicyMember](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember)
 - [LoggingLogSink](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogsink)
 - [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
 
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/log-export/org/bigquery-export@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./bigquery-export/"
     ```
 
@@ -60,23 +62,25 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPartialPolicy  loggi
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/log-export/org/pubsub-export/README.md
+++ b/catalog/log-export/org/pubsub-export/README.md
@@ -1,17 +1,20 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # PubSub Export blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A log export on a organization that sinks to PubSub
 
 ## Setters
 
-```
-Setter      Usages
-filter      1
-namespace   3
-org-id      3
-project-id  2
-topic-name  3
-```
+|    Name    |          Value           | Type | Count |
+|------------|--------------------------|------|-------|
+| filter     |                          | str  |     0 |
+| namespace  | my-namespace             | str  |     3 |
+| org-id     |             123456789012 | str  |     3 |
+| project-id | my-project-id            | str  |     2 |
+| topic-name | pubsub-logexport-dataset | str  |     3 |
 
 ## Sub-packages
 
@@ -19,13 +22,12 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File         APIVersion                                  Kind             Name                      Namespace
-export.yaml  logging.cnrm.cloud.google.com/v1beta1       LoggingLogSink   123456789012-pubsubsink   my-namespace
-export.yaml  pubsub.cnrm.cloud.google.com/v1beta1        PubSubTopic      pubsub-logexport-dataset  my-namespace
-export.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service          my-project-id-pubsub      projects
-iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  pubsub-iam-policy         my-namespace
-```
+|    File     |                 APIVersion                 |      Kind       |           Name           |  Namespace   |
+|-------------|--------------------------------------------|-----------------|--------------------------|--------------|
+| export.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service         | my-project-id-pubsub     | projects     |
+| export.yaml | logging.cnrm.cloud.google.com/v1beta1      | LoggingLogSink  | 123456789012-pubsubsink  | my-namespace |
+| export.yaml | pubsub.cnrm.cloud.google.com/v1beta1       | PubSubTopic     | pubsub-logexport-dataset | my-namespace |
+| iam.yaml    | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember | pubsub-iam-policy        | my-namespace |
 
 ## Resource References
 
@@ -37,14 +39,14 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  pubsub
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/log-export/org/pubsub-export@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./pubsub-export/"
     ```
 
@@ -52,24 +54,25 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  pubsub
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/log-export/org/storage-export/README.md
+++ b/catalog/log-export/org/storage-export/README.md
@@ -1,20 +1,23 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Cloud Storage Export blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A log export on a organization that sinks to Cloud Storage
 
 ## Setters
 
-```
-Setter               Usages
-bucket-policy-only   1
-filter               1
-location             1
-namespace            3
-org-id               3
-project-id           2
-storage-bucket-name  3
-storage-class        1
-```
+|        Name         |       Value       | Type | Count |
+|---------------------|-------------------|------|-------|
+| bucket-policy-only  | false             | bool |     1 |
+| filter              |                   | str  |     0 |
+| location            | US                | str  |     1 |
+| namespace           | my-namespace      | str  |     3 |
+| org-id              |      123456789012 | str  |     3 |
+| project-id          | my-project-id     | str  |     2 |
+| storage-bucket-name | my-storage-bucket | str  |     3 |
+| storage-class       | MULTI_REGIONAL    | str  |     1 |
 
 ## Sub-packages
 
@@ -22,13 +25,12 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File         APIVersion                                  Kind             Name                        Namespace
-export.yaml  logging.cnrm.cloud.google.com/v1beta1       LoggingLogSink   123456789012-storagesink    my-namespace
-export.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service          my-project-id-storage       projects
-export.yaml  storage.cnrm.cloud.google.com/v1beta1       StorageBucket    my-storage-bucket           my-namespace
-iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  storage-project-iam-policy  my-namespace
-```
+|    File     |                 APIVersion                 |      Kind       |            Name            |  Namespace   |
+|-------------|--------------------------------------------|-----------------|----------------------------|--------------|
+| export.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service         | my-project-id-storage      | projects     |
+| export.yaml | logging.cnrm.cloud.google.com/v1beta1      | LoggingLogSink  | 123456789012-storagesink   | my-namespace |
+| export.yaml | storage.cnrm.cloud.google.com/v1beta1      | StorageBucket   | my-storage-bucket          | my-namespace |
+| iam.yaml    | iam.cnrm.cloud.google.com/v1beta1          | IAMPolicyMember | storage-project-iam-policy | my-namespace |
 
 ## Resource References
 
@@ -40,14 +42,14 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  storag
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/log-export/org/storage-export@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./storage-export/"
     ```
 
@@ -55,24 +57,25 @@ iam.yaml     iam.cnrm.cloud.google.com/v1beta1           IAMPolicyMember  storag
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/dns/managedzone-forwarding/README.md
+++ b/catalog/networking/dns/managedzone-forwarding/README.md
@@ -37,14 +37,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/dns-forwarding-managed-zone@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/managedzone-forwarding@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./dns-forwarding-managed-zone/"
+    cd "./managedzone-forwarding/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/networking/dns/managedzone-forwarding/README.md
+++ b/catalog/networking/dns/managedzone-forwarding/README.md
@@ -1,18 +1,21 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Cloud DNS Managed Zone Forwarding blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A private Cloud DNS managed zone with forwarding config
 
 ## Setters
 
-```
-Setter                     Usages
-domain                     1
-forwarding-target-address  1
-managed-zone-name          1
-namespace                  2
-network-name               1
-project-id                 3
-```
+|           Name            |        Value         | Type | Count |
+|---------------------------|----------------------|------|-------|
+| domain                    | example.com.         | str  |     1 |
+| forwarding-target-address | 192.168.0.1          | str  |     1 |
+| managed-zone-name         | private-managed-zone | str  |     1 |
+| namespace                 | networking           | str  |     2 |
+| network-name              | example-network      | str  |     1 |
+| project-id                | project-id           | str  |     3 |
 
 ## Sub-packages
 
@@ -20,11 +23,10 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File           APIVersion                                  Kind            Name                   Namespace
-dns.yaml       dns.cnrm.cloud.google.com/v1beta1           DNSManagedZone  dnsmanagedzone-sample  networking
-services.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service         project-id-dns         projects
-```
+|     File      |                 APIVersion                 |      Kind      |         Name          | Namespace  |
+|---------------|--------------------------------------------|----------------|-----------------------|------------|
+| dns.yaml      | dns.cnrm.cloud.google.com/v1beta1          | DNSManagedZone | dnsmanagedzone-sample | networking |
+| services.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service        | project-id-dns        | projects   |
 
 ## Resource References
 
@@ -34,39 +36,40 @@ services.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service         proje
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/managedzone-forwarding@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/dns-forwarding-managed-zone@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./managedzone-forwarding/"
+    ```shell
+    cd "./dns-forwarding-managed-zone/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/dns/managedzone-peering/README.md
+++ b/catalog/networking/dns/managedzone-peering/README.md
@@ -37,14 +37,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/dns-peered-managed-zone@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/managedzone-peering@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./dns-peered-managed-zone/"
+    cd "./managedzone-peering/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/networking/dns/managedzone-peering/README.md
+++ b/catalog/networking/dns/managedzone-peering/README.md
@@ -1,18 +1,21 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Cloud DNS Managed Zone Peering blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A private Cloud DNS managed zone with peering config
 
 ## Setters
 
-```
-Setter               Usages
-domain               1
-managed-zone-name    1
-namespace            3
-network-name         1
-peered-network-name  1
-project-id           3
-```
+|        Name         |         Value          | Type | Count |
+|---------------------|------------------------|------|-------|
+| domain              | example.com.           | str  |     1 |
+| managed-zone-name   | private-managed-zone   | str  |     1 |
+| namespace           | networking             | str  |     3 |
+| network-name        | example-network        | str  |     1 |
+| peered-network-name | example-peered-network | str  |     1 |
+| project-id          | project-id             | str  |     3 |
 
 ## Sub-packages
 
@@ -20,11 +23,10 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File           APIVersion                                  Kind            Name                   Namespace
-dns.yaml       dns.cnrm.cloud.google.com/v1beta1           DNSManagedZone  dnsmanagedzone-sample  networking
-services.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service         project-id-dns         projects
-```
+|     File      |                 APIVersion                 |      Kind      |         Name          | Namespace  |
+|---------------|--------------------------------------------|----------------|-----------------------|------------|
+| dns.yaml      | dns.cnrm.cloud.google.com/v1beta1          | DNSManagedZone | dnsmanagedzone-sample | networking |
+| services.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service        | project-id-dns        | projects   |
 
 ## Resource References
 
@@ -34,39 +36,40 @@ services.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service         proje
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/managedzone-peering@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/dns-peered-managed-zone@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./managedzone-peering/"
+    ```shell
+    cd "./dns-peered-managed-zone/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/dns/managedzone-private/README.md
+++ b/catalog/networking/dns/managedzone-private/README.md
@@ -1,17 +1,20 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Cloud DNS Private Managed Zone blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A private Cloud DNS managed zone
 
 ## Setters
 
-```
-Setter             Usages
-domain             1
-managed-zone-name  1
-namespace          2
-network-name       1
-project-id         3
-```
+|       Name        |        Value         | Type | Count |
+|-------------------|----------------------|------|-------|
+| domain            | example.com.         | str  |     1 |
+| managed-zone-name | private-managed-zone | str  |     1 |
+| namespace         | networking           | str  |     2 |
+| network-name      | example-network      | str  |     1 |
+| project-id        | project-id           | str  |     3 |
 
 ## Sub-packages
 
@@ -19,11 +22,10 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File           APIVersion                                  Kind            Name                   Namespace
-dns.yaml       dns.cnrm.cloud.google.com/v1beta1           DNSManagedZone  dnsmanagedzone-sample  networking
-services.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service         project-id-dns         projects
-```
+|     File      |                 APIVersion                 |      Kind      |         Name          | Namespace  |
+|---------------|--------------------------------------------|----------------|-----------------------|------------|
+| dns.yaml      | dns.cnrm.cloud.google.com/v1beta1          | DNSManagedZone | dnsmanagedzone-sample | networking |
+| services.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service        | project-id-dns        | projects   |
 
 ## Resource References
 
@@ -33,39 +35,40 @@ services.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service         proje
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/managedzone-private@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/dns-private-managed-zone@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./managedzone-private/"
+    ```shell
+    cd "./dns-private-managed-zone/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/dns/managedzone-private/README.md
+++ b/catalog/networking/dns/managedzone-private/README.md
@@ -36,14 +36,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/dns-private-managed-zone@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/managedzone-private@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./dns-private-managed-zone/"
+    cd "./managedzone-private/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/networking/dns/policy/README.md
+++ b/catalog/networking/dns/policy/README.md
@@ -1,16 +1,19 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Cloud DNS Policy blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A Cloud DNS policy with logging and forwarding
 
 ## Setters
 
-```
-Setter           Usages
-dns-policy-name  1
-namespace        2
-network-name     1
-project-id       1
-```
+|      Name       |       Value        | Type | Count |
+|-----------------|--------------------|------|-------|
+| dns-policy-name | default-dns-policy | str  |     1 |
+| namespace       | networking         | str  |     2 |
+| network-name    | example-network    | str  |     1 |
+| project-id      | project-id         | str  |     1 |
 
 ## Sub-packages
 
@@ -18,10 +21,9 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File         APIVersion                         Kind       Name                Namespace
-policy.yaml  dns.cnrm.cloud.google.com/v1beta1  DNSPolicy  default-dns-policy  networking
-```
+|    File     |            APIVersion             |   Kind    |        Name        | Namespace  |
+|-------------|-----------------------------------|-----------|--------------------|------------|
+| policy.yaml | dns.cnrm.cloud.google.com/v1beta1 | DNSPolicy | default-dns-policy | networking |
 
 ## Resource References
 
@@ -30,39 +32,40 @@ policy.yaml  dns.cnrm.cloud.google.com/v1beta1  DNSPolicy  default-dns-policy  n
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/policy@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/dns-policy@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./policy/"
+    ```shell
+    cd "./dns-policy/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/dns/policy/README.md
+++ b/catalog/networking/dns/policy/README.md
@@ -33,14 +33,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/dns-policy@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/policy@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./dns-policy/"
+    cd "./policy/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/networking/dns/recordset/README.md
+++ b/catalog/networking/dns/recordset/README.md
@@ -1,21 +1,24 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Cloud DNS Record Set blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A Cloud DNS record set for a managed zone
 
 ## Setters
 
-```
-Setter             Usages
-domain             1
-managed-zone-name  1
-name               1
-namespace          2
-project-id         1
-records            1
-record-set-name    1
-ttl                1
-type               1
-```
+|       Name        |       Value        | Type  | Count |
+|-------------------|--------------------|-------|-------|
+| domain            | example.com.       | str   |     0 |
+| managed-zone-name | foo                | str   |     1 |
+| name              |                    | str   |     0 |
+| namespace         | networking         | str   |     2 |
+| project-id        | project-id         | str   |     1 |
+| record-set-name   | record-set-example | str   |     1 |
+| records           | [0.0.0.0]          | array |     1 |
+| ttl               |                300 | int   |     1 |
+| type              | A                  | str   |     1 |
 
 ## Sub-packages
 
@@ -23,10 +26,9 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File            APIVersion                         Kind          Name                   Namespace
-recordset.yaml  dns.cnrm.cloud.google.com/v1beta1  DNSRecordSet  dnsrecordset-sample-a  networking
-```
+|      File      |            APIVersion             |     Kind     |         Name          | Namespace  |
+|----------------|-----------------------------------|--------------|-----------------------|------------|
+| recordset.yaml | dns.cnrm.cloud.google.com/v1beta1 | DNSRecordSet | dnsrecordset-sample-a | networking |
 
 ## Resource References
 
@@ -35,39 +37,40 @@ recordset.yaml  dns.cnrm.cloud.google.com/v1beta1  DNSRecordSet  dnsrecordset-sa
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/recordset@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/dns-record-set@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./recordset/"
+    ```shell
+    cd "./dns-record-set/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/dns/recordset/README.md
+++ b/catalog/networking/dns/recordset/README.md
@@ -38,14 +38,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/dns-record-set@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/dns/recordset@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./dns-record-set/"
+    cd "./recordset/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/networking/firewall/common-rules/README.md
+++ b/catalog/networking/firewall/common-rules/README.md
@@ -62,14 +62,14 @@ This package has no top-level resources. See sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/firewall/firewall-common-rules@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/firewall/common-rules@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./firewall-common-rules/"
+    cd "./common-rules/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/networking/firewall/common-rules/README.md
+++ b/catalog/networking/firewall/common-rules/README.md
@@ -52,11 +52,19 @@ This package has no sub-packages.
 
 ## Resources
 
-This package has no top-level resources. See sub-packages.
+|                File                |              APIVersion               |      Kind       |                 Name                  |      Namespace      |
+|------------------------------------|---------------------------------------|-----------------|---------------------------------------|---------------------|
+| egress/allow-google-apis.yaml      | compute.cnrm.cloud.google.com/v1beta1 | ComputeFirewall | network-name-fw-allow-google-apis     | firewalls-namespace |
+| egress/allow-windows-kms.yaml      | compute.cnrm.cloud.google.com/v1beta1 | ComputeFirewall | network-name-fw-allow-windows-kms     | firewalls-namespace |
+| egress/deny-all.yaml               | compute.cnrm.cloud.google.com/v1beta1 | ComputeFirewall | network-name-fw-deny-all-egress       | firewalls-namespace |
+| ingress/allow-gcp-lb.yaml          | compute.cnrm.cloud.google.com/v1beta1 | ComputeFirewall | network-name-fw-allow-gcp-lb          | firewalls-namespace |
+| ingress/allow-iap-rdp.yaml         | compute.cnrm.cloud.google.com/v1beta1 | ComputeFirewall | network-name-fw-allow-iap-rdp         | firewalls-namespace |
+| ingress/allow-iap-ssh.yaml         | compute.cnrm.cloud.google.com/v1beta1 | ComputeFirewall | network-name-fw-allow-iap-ssh         | firewalls-namespace |
+| ingress/allow-internal-common.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeFirewall | network-name-fw-allow-internal-common | firewalls-namespace |
 
 ## Resource References
 
-This package has no top-level resources. See sub-packages.
+- [ComputeFirewall](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computefirewall)
 
 ## Usage
 

--- a/catalog/networking/firewall/common-rules/README.md
+++ b/catalog/networking/firewall/common-rules/README.md
@@ -1,5 +1,9 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Firewall Common Rules blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 Common firewall rules for projects with a private network.
 
 Included rules:
@@ -30,18 +34,17 @@ Contents:
 
 ## Setters
 
-```
-Setter                  Usages
-allow-default-egress    1
-dont-allow-google-apis  1
-dont-allow-windows-kms  1
-enable-logging          7
-firewall-project-id     0
-firewalls-namespace     7
-google-api-cidr         1
-network-name            14
-priority                4
-```
+|          Name          |        Value        | Type  | Count |
+|------------------------|---------------------|-------|-------|
+| allow-default-egress   | true                | bool  |     1 |
+| dont-allow-google-apis | true                | bool  |     1 |
+| dont-allow-windows-kms | true                | bool  |     1 |
+| enable-logging         | false               | bool  |     7 |
+| firewall-project-id    | firewall-project-id | str   |     0 |
+| firewalls-namespace    | firewalls-namespace | str   |     7 |
+| google-api-cidr        | [199.36.153.8/30]   | array |     1 |
+| network-name           | network-name        | str   |    14 |
+| priority               |               10000 | int   |     4 |
 
 ## Sub-packages
 
@@ -49,57 +52,49 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                                APIVersion                             Kind             Name                                   Namespace
-egress/allow-google-apis.yaml       compute.cnrm.cloud.google.com/v1beta1  ComputeFirewall  network-name-fw-allow-google-apis      firewalls-namespace
-egress/allow-windows-kms.yaml       compute.cnrm.cloud.google.com/v1beta1  ComputeFirewall  network-name-fw-allow-windows-kms      firewalls-namespace
-egress/deny-all.yaml                compute.cnrm.cloud.google.com/v1beta1  ComputeFirewall  network-name-fw-deny-all-egress        firewalls-namespace
-ingress/allow-gcp-lb.yaml           compute.cnrm.cloud.google.com/v1beta1  ComputeFirewall  network-name-fw-allow-gcp-lb           firewalls-namespace
-ingress/allow-iap-rdp.yaml          compute.cnrm.cloud.google.com/v1beta1  ComputeFirewall  network-name-fw-allow-iap-rdp          firewalls-namespace
-ingress/allow-iap-ssh.yaml          compute.cnrm.cloud.google.com/v1beta1  ComputeFirewall  network-name-fw-allow-iap-ssh          firewalls-namespace
-ingress/allow-internal-common.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeFirewall  network-name-fw-allow-internal-common  firewalls-namespace
-```
+This package has no top-level resources. See sub-packages.
 
 ## Resource References
 
-- [ComputeFirewall](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computefirewall)
+This package has no top-level resources. See sub-packages.
 
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/firewall/common-rules@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/firewall/firewall-common-rules@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./common-rules/"
+    ```shell
+    cd "./firewall-common-rules/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/network/README.md
+++ b/catalog/networking/network/README.md
@@ -1,5 +1,9 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Network blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A private network with VPN and Cloud NAT.
 
 **Requires a pre-existing secret!**
@@ -12,7 +16,7 @@ kubectl create secret generic vpn-shared-secret \
     -n ${NETWORK_NAMESPACE}
 ```
 
-Or declaratively:
+Or Config Connector:
 
 ```yaml
 apiVersion: v1
@@ -32,35 +36,33 @@ Replace the following:
 
 ## Setters
 
-```
-Setter                              Usages
-ip-cidr-range                       1
-namespace                           8
-network-name                        18
-prefix                              6
-project-id                          10
-region                              6
-source-subnetwork-ip-ranges-to-nat  1
-vpn-secret-key                      2
-vpn-secret-name                     2
-vpn-tunnel-peer-ip-01               1
-vpn-tunnel-peer-ip-02               1
-```
+|                Name                |             Value             | Type | Count |
+|------------------------------------|-------------------------------|------|-------|
+| ip-cidr-range                      | 10.2.0.0/16                   | str  |     1 |
+| namespace                          | networking                    | str  |     8 |
+| network-name                       | network-name                  | str  |    12 |
+| prefix                             |                               | str  |     0 |
+| project-id                         | project-id                    | str  |    10 |
+| region                             | us-central1                   | str  |     6 |
+| source-subnetwork-ip-ranges-to-nat | ALL_SUBNETWORKS_ALL_IP_RANGES | str  |     1 |
+| vpn-secret-key                     | vpn-shared-secret             | str  |     2 |
+| vpn-secret-name                    | vpn-shared-secret             | str  |     2 |
+| vpn-tunnel-peer-ip-01              | 15.1.0.120                    | str  |     1 |
+| vpn-tunnel-peer-ip-02              | 15.1.1.120                    | str  |     1 |
 
 ## Sub-packages
 
-- [subnet](/catalog/networking/network/subnet)
-- [vpc](/catalog/networking/network/vpc)
+- [subnetwork](subnet)
+- [vpc](vpc)
 
 ## Resources
 
-```
-File      APIVersion                             Kind                       Name                          Namespace
-vpn.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeExternalVPNGateway  network-name-ext-vpn-gateway  networking
-vpn.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeVPNGateway          network-name-ha-vpn-gateway   networking
-vpn.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeVPNTunnel           network-name-vpn-tunnel-01    networking
-vpn.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeVPNTunnel           network-name-vpn-tunnel-02    networking
-```
+|   File   |              APIVersion               |           Kind            |             Name             | Namespace  |
+|----------|---------------------------------------|---------------------------|------------------------------|------------|
+| vpn.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeVPNGateway         | network-name-ha-vpn-gateway  | networking |
+| vpn.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeExternalVPNGateway | network-name-ext-vpn-gateway | networking |
+| vpn.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeVPNTunnel          | network-name-vpn-tunnel-01   | networking |
+| vpn.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeVPNTunnel          | network-name-vpn-tunnel-02   | networking |
 
 ## Resource References
 
@@ -71,14 +73,14 @@ vpn.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeVPNTunnel           netw
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/network@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./network/"
     ```
 
@@ -86,24 +88,25 @@ vpn.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeVPNTunnel           netw
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/network/subnet/README.md
+++ b/catalog/networking/network/subnet/README.md
@@ -1,19 +1,21 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Subnetwork blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A regional subnet with Cloud NAT for public egress
 
 ## Setters
 
-```
-Setter                              Usages
-ip-cidr-range                       1
-namespace                           3
-network-name                        6
-prefix                              4
-project-id                          3
-region                              3
-source-subnetwork-ip-ranges-to-nat  1
-```
+|                Name                |             Value             | Type | Count |
+|------------------------------------|-------------------------------|------|-------|
+| ip-cidr-range                      | 10.2.0.0/16                   | str  |     1 |
+| namespace                          | networking                    | str  |     3 |
+| network-name                       | network-name                  | str  |     2 |
+| project-id                         | project-id                    | str  |     3 |
+| region                             | us-central1                   | str  |     3 |
+| source-subnetwork-ip-ranges-to-nat | ALL_SUBNETWORKS_ALL_IP_RANGES | str  |     1 |
 
 ## Sub-packages
 
@@ -21,55 +23,55 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File         APIVersion                             Kind               Name                     Namespace
-nat.yaml     compute.cnrm.cloud.google.com/v1beta1  ComputeRouterNAT   network-name-router-nat  networking
-nat.yaml     compute.cnrm.cloud.google.com/v1beta1  ComputeRouter      network-name-router      networking
-subnet.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeSubnetwork  network-name-subnetwork  networking
-```
+|    File     |              APIVersion               |       Kind        |          Name           | Namespace  |
+|-------------|---------------------------------------|-------------------|-------------------------|------------|
+| nat.yaml    | compute.cnrm.cloud.google.com/v1beta1 | ComputeRouterNAT  | network-name-router-nat | networking |
+| nat.yaml    | compute.cnrm.cloud.google.com/v1beta1 | ComputeRouter     | network-name-router     | networking |
+| subnet.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeSubnetwork | network-name-subnetwork | networking |
 
 ## Resource References
 
-- [ComputeRouter](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computerouter)
 - [ComputeRouterNAT](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computerouternat)
+- [ComputeRouter](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computerouter)
 - [ComputeSubnetwork](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computesubnetwork)
 
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/network/subnet@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/network/subnetwork@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./subnet/"
+    ```shell
+    cd "./subnetwork/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/network/subnet/README.md
+++ b/catalog/networking/network/subnet/README.md
@@ -39,14 +39,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/network/subnetwork@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/network/subnet@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./subnetwork/"
+    cd "./subnet/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/networking/network/vpc/README.md
+++ b/catalog/networking/network/vpc/README.md
@@ -1,15 +1,18 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Virtual Private Cloud blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A Virtual Private Cloud (VPC)
 
 ## Setters
 
-```
-Setter        Usages
-namespace     1
-network-name  1
-project-id    3
-```
+|     Name     |    Value     | Type | Count |
+|--------------|--------------|------|-------|
+| namespace    | networking   | str  |     1 |
+| network-name | network-name | str  |     1 |
+| project-id   | project-id   | str  |     3 |
 
 ## Sub-packages
 
@@ -17,11 +20,10 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File           APIVersion                                  Kind            Name                Namespace
-services.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service         project-id-compute  projects
-vpc.yaml       compute.cnrm.cloud.google.com/v1beta1       ComputeNetwork  network-name        networking
-```
+|     File      |                 APIVersion                 |      Kind      |        Name        | Namespace  |
+|---------------|--------------------------------------------|----------------|--------------------|------------|
+| services.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service        | project-id-compute | projects   |
+| vpc.yaml      | compute.cnrm.cloud.google.com/v1beta1      | ComputeNetwork | network-name       | networking |
 
 ## Resource References
 
@@ -31,14 +33,14 @@ vpc.yaml       compute.cnrm.cloud.google.com/v1beta1       ComputeNetwork  netwo
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/network/vpc@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./vpc/"
     ```
 
@@ -46,24 +48,25 @@ vpc.yaml       compute.cnrm.cloud.google.com/v1beta1       ComputeNetwork  netwo
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/peering/README.md
+++ b/catalog/networking/peering/README.md
@@ -1,15 +1,18 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Network Peering blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A peering between two private networks
 
 ## Setters
 
-```
-Setter         Usages
-local-network  4
-namespace      6
-peer-network   4
-```
+|     Name      |     Value     | Type | Count |
+|---------------|---------------|------|-------|
+| local-network | local-network | str  |     4 |
+| namespace     | networking    | str  |     6 |
+| peer-network  | peer-network  | str  |     4 |
 
 ## Sub-packages
 
@@ -17,11 +20,10 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File          APIVersion                             Kind                   Name                           Namespace
-peering.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeNetworkPeering  local-network-to-peer-network  namespace
-peering.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeNetworkPeering  peer-network-to-local-network  namespace
-```
+|     File     |              APIVersion               |         Kind          |             Name              | Namespace |
+|--------------|---------------------------------------|-----------------------|-------------------------------|-----------|
+| peering.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeNetworkPeering | local-network-to-peer-network | namespace |
+| peering.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeNetworkPeering | peer-network-to-local-network | namespace |
 
 ## Resource References
 
@@ -30,39 +32,40 @@ peering.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeNetworkPeering  peer
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/peering@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/network-peering@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./peering/"
+    ```shell
+    cd "./network-peering/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/peering/README.md
+++ b/catalog/networking/peering/README.md
@@ -33,14 +33,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/network-peering@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/peering@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./network-peering/"
+    cd "./peering/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/networking/routes/routes-igw/README.md
+++ b/catalog/networking/routes/routes-igw/README.md
@@ -1,17 +1,20 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Internet Gateway Compute Route blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 An egress route to the default internet gateway
 
 ## Setters
 
-```
-Setter             Usages
-destination-range  1
-namespace          2
-network-name       1
-project-id         1
-route-name         1
-```
+|       Name        |     Value     | Type | Count |
+|-------------------|---------------|------|-------|
+| destination-range | 0.0.0.0/0     | str  |     1 |
+| namespace         | networking    | str  |     2 |
+| network-name      | network-name  | str  |     1 |
+| project-id        | project-id    | str  |     1 |
+| route-name        | route-example | str  |     1 |
 
 ## Sub-packages
 
@@ -19,10 +22,9 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File        APIVersion                             Kind          Name           Namespace
-route.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeRoute  route-example  networking
-```
+|    File    |              APIVersion               |     Kind     |     Name      | Namespace  |
+|------------|---------------------------------------|--------------|---------------|------------|
+| route.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeRoute | route-example | networking |
 
 ## Resource References
 
@@ -31,39 +33,40 @@ route.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeRoute  route-example  
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/routes/routes-igw@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/routes/compute-route-igw@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./routes-igw/"
+    ```shell
+    cd "./compute-route-igw/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/routes/routes-igw/README.md
+++ b/catalog/networking/routes/routes-igw/README.md
@@ -34,14 +34,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/routes/compute-route-igw@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/routes/routes-igw@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./compute-route-igw/"
+    cd "./routes-igw/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/networking/shared-vpc/README.md
+++ b/catalog/networking/shared-vpc/README.md
@@ -1,5 +1,9 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Shared VPC Host Project blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 Configures a project as the Host project for a Shared VPC.
 
 Creation of a Shared VPC requires **compute.organizations.enableXpnHost**
@@ -7,11 +11,10 @@ permission on the org. This permission can only be granted by an org admin.
 
 ## Setters
 
-```
-Setter      Usages
-namespace   1
-project-id  2
-```
+|    Name    |   Value    | Type | Count |
+|------------|------------|------|-------|
+| namespace  | networking | str  |     1 |
+| project-id | project-id | str  |     2 |
 
 ## Sub-packages
 
@@ -19,10 +22,9 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File            APIVersion                             Kind                         Name                  Namespace
-sharedVPC.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeSharedVPCHostProject  project-id-sharedvpc  networking
-```
+|      File      |              APIVersion               |            Kind             |         Name         | Namespace  |
+|----------------|---------------------------------------|-----------------------------|----------------------|------------|
+| sharedVPC.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeSharedVPCHostProject | project-id-sharedvpc | networking |
 
 ## Resource References
 
@@ -31,14 +33,14 @@ sharedVPC.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeSharedVPCHostProje
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/shared-vpc@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./shared-vpc/"
     ```
 
@@ -46,24 +48,25 @@ sharedVPC.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeSharedVPCHostProje
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/svpc-service-project/README.md
+++ b/catalog/networking/svpc-service-project/README.md
@@ -1,15 +1,18 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Shared VPC Service Project blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A service project to attach to a Shared VPC
 
 ## Setters
 
-```
-Setter           Usages
-host-project-id  1
-namespace        2
-project-id       2
-```
+|      Name       |    Value     | Type | Count |
+|-----------------|--------------|------|-------|
+| host-project-id | host-project | str  |     1 |
+| namespace       | projects     | str  |     2 |
+| project-id      | project-id   | str  |     2 |
 
 ## Sub-packages
 
@@ -17,10 +20,9 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                 APIVersion                             Kind                            Name                     Namespace
-serviceproject.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeSharedVPCServiceProject  project-id-svpc-service  networking
-```
+|        File         |              APIVersion               |              Kind              |          Name           | Namespace  |
+|---------------------|---------------------------------------|--------------------------------|-------------------------|------------|
+| serviceproject.yaml | compute.cnrm.cloud.google.com/v1beta1 | ComputeSharedVPCServiceProject | project-id-svpc-service | networking |
 
 ## Resource References
 
@@ -29,14 +31,14 @@ serviceproject.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeSharedVPCServ
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/svpc-service-project@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./svpc-service-project/"
     ```
 
@@ -44,24 +46,25 @@ serviceproject.yaml  compute.cnrm.cloud.google.com/v1beta1  ComputeSharedVPCServ
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/vpc-service-controls/access-policy/README.md
+++ b/catalog/networking/vpc-service-controls/access-policy/README.md
@@ -1,15 +1,18 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Service Controls Access Policy blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 An org-level access policy using the Access Context Manager
 
 ## Setters
 
-```
-Setter              Usages
-access-policy-name  2
-namespace           1
-org-id              1
-```
+|        Name        |       Value       | Type | Count |
+|--------------------|-------------------|------|-------|
+| access-policy-name | org-access-policy | str  |     2 |
+| namespace          | networking        | str  |     1 |
+| org-id             | example-org       | str  |     1 |
 
 ## Sub-packages
 
@@ -17,10 +20,9 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File         APIVersion                                          Kind                              Name               Namespace
-policy.yaml  accesscontextmanager.cnrm.cloud.google.com/v1beta1  AccessContextManagerAccessPolicy  org-access-policy  networking
-```
+|    File     |                     APIVersion                     |               Kind               |       Name        | Namespace  |
+|-------------|----------------------------------------------------|----------------------------------|-------------------|------------|
+| policy.yaml | accesscontextmanager.cnrm.cloud.google.com/v1beta1 | AccessContextManagerAccessPolicy | org-access-policy | networking |
 
 ## Resource References
 
@@ -29,39 +31,40 @@ policy.yaml  accesscontextmanager.cnrm.cloud.google.com/v1beta1  AccessContextMa
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/vpc-service-controls/access-policy@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/vpc-service-controls/service-controls-access-policy@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./access-policy/"
+    ```shell
+    cd "./service-controls-access-policy/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/vpc-service-controls/access-policy/README.md
+++ b/catalog/networking/vpc-service-controls/access-policy/README.md
@@ -32,14 +32,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/vpc-service-controls/service-controls-access-policy@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/vpc-service-controls/access-policy@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./service-controls-access-policy/"
+    cd "./access-policy/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/networking/vpc-service-controls/perimeter/README.md
+++ b/catalog/networking/vpc-service-controls/perimeter/README.md
@@ -1,21 +1,24 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Service Controls Perimeter blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A basic access level restricting access to a specific region using the
 Access Context Manager
 
 ## Setters
 
-```
-Setter               Usages
-access-policy-name   2
-namespace            4
-org-id               1
-perimeter-name       5
-project-id           1
-project-namespace    1
-restricted-services  1
-suffix               5
-```
+|        Name         |                       Value                       | Type  | Count |
+|---------------------|---------------------------------------------------|-------|-------|
+| access-policy-name  | org-access-policy                                 | str   |     2 |
+| namespace           | networking                                        | str   |     4 |
+| org-id              | example-org                                       | str   |     1 |
+| perimeter-name      | regionperimeter                                   | str   |     0 |
+| project-id          | vpcsc-project-id                                  | str   |     1 |
+| project-namespace   | projects                                          | str   |     1 |
+| restricted-services | [storage.googleapis.com, bigquery.googleapis.com] | array |     1 |
+| suffix              |                                                   | str   |     0 |
 
 ## Sub-packages
 
@@ -23,11 +26,10 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File               APIVersion                                          Kind                                  Name                Namespace
-access-level.yaml  accesscontextmanager.cnrm.cloud.google.com/v1beta1  AccessContextManagerAccessLevel       alregionperimeter   networking
-perimeter.yaml     accesscontextmanager.cnrm.cloud.google.com/v1beta1  AccessContextManagerServicePerimeter  spcregionperimeter  networking
-```
+|       File        |                     APIVersion                     |                 Kind                 |        Name        | Namespace  |
+|-------------------|----------------------------------------------------|--------------------------------------|--------------------|------------|
+| access-level.yaml | accesscontextmanager.cnrm.cloud.google.com/v1beta1 | AccessContextManagerAccessLevel      | alregionperimeter  | networking |
+| perimeter.yaml    | accesscontextmanager.cnrm.cloud.google.com/v1beta1 | AccessContextManagerServicePerimeter | spcregionperimeter | networking |
 
 ## Resource References
 
@@ -37,39 +39,40 @@ perimeter.yaml     accesscontextmanager.cnrm.cloud.google.com/v1beta1  AccessCon
 ## Usage
 
 1.  Clone the package:
-    ```
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/vpc-service-controls/perimeter@${VERSION}
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/vpc-service-controls/service-controls-perimeter@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
-    cd "./perimeter/"
+    ```shell
+    cd "./service-controls-perimeter/"
     ```
 
 1.  Edit the function config file(s):
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/networking/vpc-service-controls/perimeter/README.md
+++ b/catalog/networking/vpc-service-controls/perimeter/README.md
@@ -40,14 +40,14 @@ This package has no sub-packages.
 
 1.  Clone the package:
     ```shell
-    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/vpc-service-controls/service-controls-perimeter@${VERSION}
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/networking/vpc-service-controls/perimeter@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
     ```shell
-    cd "./service-controls-perimeter/"
+    cd "./perimeter/"
     ```
 
 1.  Edit the function config file(s):

--- a/catalog/project/README.md
+++ b/catalog/project/README.md
@@ -15,7 +15,7 @@ Config Connector.
 | folder-name           | name.of.folder        | str  |     1 |
 | folder-namespace      | hierarchy             | str  |     1 |
 | management-namespace  | config-control        | str  |     2 |
-| management-project-id | management-project-id | str  |     6 |
+| management-project-id | management-project-id | str  |     5 |
 | networking-namespace  | networking            | str  |     1 |
 | project-id            | project-id            | str  |    18 |
 | projects-namespace    | projects              | str  |     3 |

--- a/catalog/project/README.md
+++ b/catalog/project/README.md
@@ -1,32 +1,34 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Project blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 A project and a project namespace in which to manage project resources with
 Config Connector.
 
 ## Setters
 
-```
-Setter                 Usages
-billing-account-id     1
-folder-name            1
-folder-namespace       1
-management-namespace   2
-management-project-id  6
-networking-namespace   1
-project-id             18
-projects-namespace     3
-```
+|         Name          |         Value         | Type | Count |
+|-----------------------|-----------------------|------|-------|
+| billing-account-id    | AAAAAA-BBBBBB-CCCCCC  | str  |     1 |
+| folder-name           | name.of.folder        | str  |     1 |
+| folder-namespace      | hierarchy             | str  |     1 |
+| management-namespace  | config-control        | str  |     2 |
+| management-project-id | management-project-id | str  |     6 |
+| networking-namespace  | networking            | str  |     1 |
+| project-id            | project-id            | str  |    18 |
+| projects-namespace    | projects              | str  |     3 |
 
 ## Sub-packages
 
-- [kcc-namespace](/catalog/project/kcc-namespace)
+- [kcc-namespace](kcc-namespace)
 
 ## Resources
 
-```
-File          APIVersion                                     Kind     Name        Namespace
-project.yaml  resourcemanager.cnrm.cloud.google.com/v1beta1  Project  project-id  projects
-```
+|     File     |                  APIVersion                   |  Kind   |    Name    | Namespace |
+|--------------|-----------------------------------------------|---------|------------|-----------|
+| project.yaml | resourcemanager.cnrm.cloud.google.com/v1beta1 | Project | project-id | projects  |
 
 ## Resource References
 
@@ -35,14 +37,14 @@ project.yaml  resourcemanager.cnrm.cloud.google.com/v1beta1  Project  project-id
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/project@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./project/"
     ```
 
@@ -50,24 +52,25 @@ project.yaml  resourcemanager.cnrm.cloud.google.com/v1beta1  Project  project-id
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/project/kcc-namespace/README.md
+++ b/catalog/project/kcc-namespace/README.md
@@ -1,18 +1,21 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Project Namespace Package
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 Kubernetes namespace configured for use with Config Connector to manage GCP
 resources in a specific project.
 
 ## Setters
 
-```
-Setter                 Usages
-management-namespace   2
-management-project-id  6
-networking-namespace   1
-project-id             16
-projects-namespace     2
-```
+|         Name          |         Value         | Type | Count |
+|-----------------------|-----------------------|------|-------|
+| management-namespace  | config-control        | str  |     2 |
+| management-project-id | management-project-id | str  |     6 |
+| networking-namespace  | networking            | str  |     1 |
+| project-id            | project-id            | str  |    16 |
+| projects-namespace    | projects              | str  |     2 |
 
 ## Sub-packages
 
@@ -20,36 +23,35 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                       APIVersion                          Kind                    Name                                               Namespace
-kcc-namespace-viewer.yaml  rbac.authorization.k8s.io/v1        RoleBinding             cnrm-network-viewer-project-id                     networking
-kcc-namespace-viewer.yaml  rbac.authorization.k8s.io/v1        RoleBinding             cnrm-project-viewer-project-id                     projects
-kcc-project-owner.yaml     iam.cnrm.cloud.google.com/v1beta1   IAMPartialPolicy         kcc-project-id-owners-permissions                  projects
-kcc.yaml                   core.cnrm.cloud.google.com/v1beta1  ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  project-id
-kcc.yaml                   iam.cnrm.cloud.google.com/v1beta1   IAMPartialPolicy         project-id-sa-workload-identity-binding            config-control
-kcc.yaml                   iam.cnrm.cloud.google.com/v1beta1   IAMServiceAccount       kcc-project-id                                     config-control
-namespace.yaml             v1                                  Namespace               project-id
-```
+|           File            |             APIVersion             |          Kind          |                       Name                        |   Namespace    |
+|---------------------------|------------------------------------|------------------------|---------------------------------------------------|----------------|
+| kcc-namespace-viewer.yaml | rbac.authorization.k8s.io/v1       | RoleBinding            | cnrm-network-viewer-project-id                    | networking     |
+| kcc-namespace-viewer.yaml | rbac.authorization.k8s.io/v1       | RoleBinding            | cnrm-project-viewer-project-id                    | projects       |
+| kcc-project-owner.yaml    | iam.cnrm.cloud.google.com/v1beta1  | IAMPartialPolicy       | kcc-project-id-owners-permissions                 | projects       |
+| kcc.yaml                  | core.cnrm.cloud.google.com/v1beta1 | ConfigConnectorContext | configconnectorcontext.core.cnrm.cloud.google.com | project-id     |
+| kcc.yaml                  | iam.cnrm.cloud.google.com/v1beta1  | IAMServiceAccount      | kcc-project-id                                    | config-control |
+| kcc.yaml                  | iam.cnrm.cloud.google.com/v1beta1  | IAMPartialPolicy       | project-id-sa-workload-identity-binding           | config-control |
+| namespace.yaml            | v1                                 | Namespace              | project-id                                        |                |
 
 ## Resource References
 
 - [ConfigConnectorContext](https://cloud.google.com/config-connector/docs/how-to/advanced-install#addon-configuring)
 - [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
 - [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)
-- [Namespace](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#namespace-v1-core)
-- [RoleBinding](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#rolebinding-v1-rbac-authorization-k8s-io)
+- [Namespace](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#namespace-v1-core)
+- [RoleBinding](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#rolebinding-v1-rbac-authorization-k8s-io)
 
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/project/kcc-namespace@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./kcc-namespace/"
     ```
 
@@ -57,23 +59,25 @@ namespace.yaml             v1                                  Namespace        
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/project/kcc-namespace/README.md
+++ b/catalog/project/kcc-namespace/README.md
@@ -12,7 +12,7 @@ resources in a specific project.
 |         Name          |         Value         | Type | Count |
 |-----------------------|-----------------------|------|-------|
 | management-namespace  | config-control        | str  |     2 |
-| management-project-id | management-project-id | str  |     6 |
+| management-project-id | management-project-id | str  |     5 |
 | networking-namespace  | networking            | str  |     1 |
 | project-id            | project-id            | str  |    16 |
 | projects-namespace    | projects              | str  |     2 |

--- a/catalog/redis-bucket/README.md
+++ b/catalog/redis-bucket/README.md
@@ -1,20 +1,24 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Google Cloud Storage and Memorystore for Redis blueprint
 
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 Google Cloud Storage (GCS) bucket and Memorystore for Redis instance.
 
 This blueprint demonstrates multiple unrelated resources sharing a package.
 
 ## Setters
 
-```
-Setter         Usages
-name           4
-namespace      3
-network        1
-project-id     8
-region         1
-storage-class  1
-```
+|     Name      |          Value           | Type | Count |
+|---------------|--------------------------|------|-------|
+| name          | redis-bucket             | str  |     4 |
+| namespace     | config-control           | str  |     3 |
+| network       | default                  | str  |     1 |
+| project-id    | blueprints-project-redis | str  |     8 |
+| region        | us-central1              | str  |     1 |
+| storage-class | standard                 | str  |     1 |
 
 ## Sub-packages
 
@@ -22,12 +26,11 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File         APIVersion                                  Kind           Name                             Namespace
-bucket.yaml  storage.cnrm.cloud.google.com/v1beta1       StorageBucket  blueprints-project-redis-bucket  config-control
-redis.yaml   redis.cnrm.cloud.google.com/v1beta1         RedisInstance  blueprints-project-redis-bucket  config-controller-system
-redis.yaml   serviceusage.cnrm.cloud.google.com/v1beta1  Service        blueprints-project-redis-bucket  config-control
-```
+|    File     |                 APIVersion                 |     Kind      |              Name               |        Namespace         |
+|-------------|--------------------------------------------|---------------|---------------------------------|--------------------------|
+| bucket.yaml | storage.cnrm.cloud.google.com/v1beta1      | StorageBucket | blueprints-project-redis-bucket | config-control           |
+| redis.yaml  | serviceusage.cnrm.cloud.google.com/v1beta1 | Service       | blueprints-project-redis-bucket | config-control           |
+| redis.yaml  | redis.cnrm.cloud.google.com/v1beta1        | RedisInstance | blueprints-project-redis-bucket | config-controller-system |
 
 ## Resource References
 
@@ -38,14 +41,14 @@ redis.yaml   serviceusage.cnrm.cloud.google.com/v1beta1  Service        blueprin
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/redis-bucket@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./redis-bucket/"
     ```
 
@@ -53,24 +56,25 @@ redis.yaml   serviceusage.cnrm.cloud.google.com/v1beta1  Service        blueprin
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/spanner/README.md
+++ b/catalog/spanner/README.md
@@ -1,17 +1,20 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
 # Spanner blueprint
 
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
 Spanner database and instance with deletion policy
 
 ## Setters
 
-```
-Setter         Usages
-config-region  1
-database-name  1
-instance-name  3
-namespace      2
-num-nodes      1
-```
+|     Name      |          Value          | Type | Count |
+|---------------|-------------------------|------|-------|
+| config-region | regional-us-central1    | str  |     1 |
+| database-name | spanner-sample-database | str  |     1 |
+| instance-name | spanner-sample-instance | str  |     3 |
+| namespace     | my-namespace            | str  |     2 |
+| num-nodes     |                       1 | int  |     1 |
 
 ## Sub-packages
 
@@ -19,30 +22,27 @@ This package has no sub-packages.
 
 ## Resources
 
-```
-File                                               APIVersion                             Kind                      Name                                                 Namespace
-policies/deletion-policy-required-constraint.yaml  constraints.gatekeeper.sh/v1beta1      GCPRequireDeletionPolicy  enforce-deletion-policy-annotation-spanner-instance
-spanner.yaml                                       spanner.cnrm.cloud.google.com/v1beta1  SpannerDatabase           spanner-sample-database                              my-namespace
-spanner.yaml                                       spanner.cnrm.cloud.google.com/v1beta1  SpannerInstance           spanner-sample-instance                              my-namespace
-```
+|     File     |              APIVersion               |      Kind       |          Name           |  Namespace   |
+|--------------|---------------------------------------|-----------------|-------------------------|--------------|
+| spanner.yaml | spanner.cnrm.cloud.google.com/v1beta1 | SpannerDatabase | spanner-sample-database | my-namespace |
+| spanner.yaml | spanner.cnrm.cloud.google.com/v1beta1 | SpannerInstance | spanner-sample-instance | my-namespace |
 
 ## Resource References
 
-- GCPRequireDeletionPolicy
 - [SpannerDatabase](https://cloud.google.com/config-connector/docs/reference/resource-docs/spanner/spannerdatabase)
 - [SpannerInstance](https://cloud.google.com/config-connector/docs/reference/resource-docs/spanner/spannerinstance)
 
 ## Usage
 
 1.  Clone the package:
-    ```
+    ```shell
     kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/spanner@${VERSION}
     ```
     Replace `${VERSION}` with the desired repo branch or tag
     (for example, `main`).
 
 1.  Move into the local package:
-    ```
+    ```shell
     cd "./spanner/"
     ```
 
@@ -50,24 +50,25 @@ spanner.yaml                                       spanner.cnrm.cloud.google.com
     - setters.yaml
 
 1.  Execute the function pipeline
-    ```
+    ```shell
     kpt fn render
     ```
 
 1.  Initialize the resource inventory
-    ```
+    ```shell
     kpt live init --namespace ${NAMESPACE}"
     ```
     Replace `${NAMESPACE}` with the namespace in which to manage
     the inventory ResourceGroup (for example, `config-control`).
 
 1.  Apply the package resources to your cluster
-    ```
+    ```shell
     kpt live apply
     ```
 
 1.  Wait for the resources to be ready
-    ```
+    ```shell
     kpt live status --output table --poll-until current
     ```
 
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/spanner/README.md
+++ b/catalog/spanner/README.md
@@ -22,13 +22,15 @@ This package has no sub-packages.
 
 ## Resources
 
-|     File     |              APIVersion               |      Kind       |          Name           |  Namespace   |
-|--------------|---------------------------------------|-----------------|-------------------------|--------------|
-| spanner.yaml | spanner.cnrm.cloud.google.com/v1beta1 | SpannerDatabase | spanner-sample-database | my-namespace |
-| spanner.yaml | spanner.cnrm.cloud.google.com/v1beta1 | SpannerInstance | spanner-sample-instance | my-namespace |
+|                       File                        |              APIVersion               |           Kind           |                        Name                         |  Namespace   |
+|---------------------------------------------------|---------------------------------------|--------------------------|-----------------------------------------------------|--------------|
+| policies/deletion-policy-required-constraint.yaml | constraints.gatekeeper.sh/v1beta1     | GCPRequireDeletionPolicy | enforce-deletion-policy-annotation-spanner-instance |              |
+| spanner.yaml                                      | spanner.cnrm.cloud.google.com/v1beta1 | SpannerDatabase          | spanner-sample-database                             | my-namespace |
+| spanner.yaml                                      | spanner.cnrm.cloud.google.com/v1beta1 | SpannerInstance          | spanner-sample-instance                             | my-namespace |
 
 ## Resource References
 
+- GCPRequireDeletionPolicy
 - [SpannerDatabase](https://cloud.google.com/config-connector/docs/reference/resource-docs/spanner/spannerdatabase)
 - [SpannerInstance](https://cloud.google.com/config-connector/docs/reference/resource-docs/spanner/spannerinstance)
 

--- a/utils/fix-readmes.sh
+++ b/utils/fix-readmes.sh
@@ -33,7 +33,7 @@ function fix_readmes() {
             echo "Generating ${child}/README.md"
             pushd ${child}
              pkgName=$(basename $child)
-             kpt fn eval -i gcr.io/kpt-fn-contrib/generate-kpt-pkg-docs:unstable --image-pull-policy never --include-meta-resources --mount type=bind,src="$(pwd)",dst=/tmp,rw=true -- readme-path=/tmp/README.md repo-path="https://github.com/GoogleCloudPlatform/blueprints.git/${parent}/" pkg-name="${pkgName}"
+             kpt fn eval -i gcr.io/kpt-fn-contrib/generate-kpt-pkg-docs@sha256:046b57ae98fc7c0ae35713fcf50d8d0c2c34fcd1d576dec516ac075cc9f8d519 --include-meta-resources --mount type=bind,src="$(pwd)",dst=/tmp,rw=true -- readme-path=/tmp/README.md repo-path="https://github.com/GoogleCloudPlatform/blueprints.git/${parent}/" pkg-name="${pkgName}"
             popd
         fi
         fix_readmes "${child}"

--- a/utils/fix-readmes.sh
+++ b/utils/fix-readmes.sh
@@ -32,7 +32,8 @@ function fix_readmes() {
             # kpt package
             echo "Generating ${child}/README.md"
             pushd ${child}
-             kpt fn eval -i gcr.io/kpt-fn-contrib/generate-kpt-pkg-docs:unstable --image-pull-policy never --include-meta-resources --mount type=bind,src="$(pwd)",dst=/tmp,rw=true -- readme-path=/tmp/README.md repo-path="https://github.com/GoogleCloudPlatform/blueprints.git/${parent}/"
+             pkgName=$(basename $child)
+             kpt fn eval -i gcr.io/kpt-fn-contrib/generate-kpt-pkg-docs:unstable --image-pull-policy never --include-meta-resources --mount type=bind,src="$(pwd)",dst=/tmp,rw=true -- readme-path=/tmp/README.md repo-path="https://github.com/GoogleCloudPlatform/blueprints.git/${parent}/" pkg-name="${pkgName}"
             popd
         fi
         fix_readmes "${child}"

--- a/utils/fix-readmes.sh
+++ b/utils/fix-readmes.sh
@@ -18,10 +18,7 @@ set -o errexit -o nounset -o pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${REPO_ROOT}"
 
-PKG_PATH="${1:-.}"
-if [[ -z "${PKG_PATH}" ]]; then
-    PKG_PATH="catalog"
-fi
+PKG_PATH="${1:-catalog}"
 
 function fix_readmes() {
     local parent="${1}"
@@ -34,7 +31,9 @@ function fix_readmes() {
         if [[ -f "${child}/Kptfile" ]]; then
             # kpt package
             echo "Generating ${child}/README.md"
-            utils/kpt-pkg-readme.sh "${child}" > "${child}/README.md"
+            pushd ${child}
+             kpt fn eval -i gcr.io/kpt-fn-contrib/generate-kpt-pkg-docs:unstable --image-pull-policy never --include-meta-resources --mount type=bind,src="$(pwd)",dst=/tmp,rw=true -- readme-path=/tmp/README.md repo-path="https://github.com/GoogleCloudPlatform/blueprints.git/${parent}/"
+            popd
         fi
         fix_readmes "${child}"
     done < <(find "${parent}" -mindepth 1 -maxdepth 1 -type d -print0)


### PR DESCRIPTION
This updates doc generation script to use [generate-kpt-pkg-docs](https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/contrib/functions/go/generate-kpt-pkg-docs) to generate documentation.

This will be added to CI check in a follow up PR.
