### PR TITLE
fix: remove redundant project annotation from IAMPartialPolicy

### DIFF
--- a/catalog/project/kcc-namespace/kcc.yaml
+++ b/catalog/project/kcc-namespace/kcc.yaml
@@ -42,7 +42,6 @@ metadata:
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.4.1
-    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:
     name: kcc-project-id # kpt-set: kcc-${project-id}


### PR DESCRIPTION
The resourceRef already covers this.