### PR TITLE
fix: remove namespace setters from bucket and redis blueprints

### DIFF
--- a/catalog/bucket/README.md
+++ b/catalog/bucket/README.md
@@ -10,8 +10,7 @@ A Google Cloud Storage bucket
 
 |     Name      |       Value        | Type | Count |
 |---------------|--------------------|------|-------|
-| name          | bucket2            | str  |     1 |
-| namespace     | config-control     | str  |     1 |
+| name          | bucket             | str  |     1 |
 | project-id    | blueprints-project | str  |     2 |
 | storage-class | standard           | str  |     1 |
 

--- a/catalog/bucket/bucket.yaml
+++ b/catalog/bucket/bucket.yaml
@@ -15,7 +15,7 @@ apiVersion: storage.cnrm.cloud.google.com/v1beta1
 kind: StorageBucket
 metadata:
   name: blueprints-project-bucket # kpt-set: ${project-id}-${name}
-  namespace: config-control # kpt-set: ${namespace}
+  namespace: config-control
   annotations:
     cnrm.cloud.google.com/force-destroy: "false"
     cnrm.cloud.google.com/project-id: blueprints-project # kpt-set: ${project-id}

--- a/catalog/bucket/setters.yaml
+++ b/catalog/bucket/setters.yaml
@@ -17,6 +17,5 @@ metadata:
   name: setters
 data:
   name: bucket2
-  namespace: config-control
   #project-id: project-id
   storage-class: standard

--- a/catalog/redis-bucket/README.md
+++ b/catalog/redis-bucket/README.md
@@ -13,8 +13,7 @@ This blueprint demonstrates multiple unrelated resources sharing a package.
 
 |     Name      |          Value           | Type | Count |
 |---------------|--------------------------|------|-------|
-| name          | redis-bucket             | str  |     4 |
-| namespace     | config-control           | str  |     3 |
+| name          | bucket                   | str  |     4 |
 | network       | default                  | str  |     1 |
 | project-id    | blueprints-project-redis | str  |     8 |
 | region        | us-central1              | str  |     1 |
@@ -26,11 +25,11 @@ This package has no sub-packages.
 
 ## Resources
 
-|    File     |                 APIVersion                 |     Kind      |              Name               |        Namespace         |
-|-------------|--------------------------------------------|---------------|---------------------------------|--------------------------|
-| bucket.yaml | storage.cnrm.cloud.google.com/v1beta1      | StorageBucket | blueprints-project-redis-bucket | config-control           |
-| redis.yaml  | serviceusage.cnrm.cloud.google.com/v1beta1 | Service       | blueprints-project-redis-bucket | config-control           |
-| redis.yaml  | redis.cnrm.cloud.google.com/v1beta1        | RedisInstance | blueprints-project-redis-bucket | config-controller-system |
+|    File     |                 APIVersion                 |     Kind      |              Name               |   Namespace    |
+|-------------|--------------------------------------------|---------------|---------------------------------|----------------|
+| bucket.yaml | storage.cnrm.cloud.google.com/v1beta1      | StorageBucket | blueprints-project-redis-bucket | config-control |
+| redis.yaml  | serviceusage.cnrm.cloud.google.com/v1beta1 | Service       | blueprints-project-redis-bucket | config-control |
+| redis.yaml  | redis.cnrm.cloud.google.com/v1beta1        | RedisInstance | blueprints-project-redis-bucket | config-control |
 
 ## Resource References
 

--- a/catalog/redis-bucket/bucket.yaml
+++ b/catalog/redis-bucket/bucket.yaml
@@ -15,7 +15,7 @@ apiVersion: storage.cnrm.cloud.google.com/v1beta1
 kind: StorageBucket
 metadata:
   name: blueprints-project-redis-bucket # kpt-set: ${project-id}-${name}
-  namespace: config-control # kpt-set: ${namespace}
+  namespace: config-control
   annotations:
     cnrm.cloud.google.com/force-destroy: "false"
     cnrm.cloud.google.com/project-id: blueprints-project # kpt-set: ${project-id}

--- a/catalog/redis-bucket/redis.yaml
+++ b/catalog/redis-bucket/redis.yaml
@@ -15,7 +15,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   name: blueprints-project-redis-bucket # kpt-set: ${project-id}-${name}
-  namespace: config-control # kpt-set: ${namespace}
+  namespace: config-control
   annotations:
     cnrm.cloud.google.com/disable-on-destroy: "false"
     cnrm.cloud.google.com/project-id: blueprints-project # kpt-set: ${project-id}
@@ -26,7 +26,7 @@ apiVersion: redis.cnrm.cloud.google.com/v1beta1
 kind: RedisInstance
 metadata:
   name: blueprints-project-redis-bucket # kpt-set: ${project-id}-${name}
-  namespace: config-controller-system # kpt-set: ${namespace}
+  namespace: config-control
   annotations:
     cnrm.cloud.google.com/project-id: blueprints-project # kpt-set: ${project-id}
 spec:

--- a/catalog/redis-bucket/setters.yaml
+++ b/catalog/redis-bucket/setters.yaml
@@ -17,7 +17,6 @@ metadata:
   name: setters
 data:
   name: redis-bucket
-  namespace: config-control
   network: default
   #project-id: project-id
   region: us-central1


### PR DESCRIPTION
Also make sure they use `config-control` as the default namespace.