### PR TITLE
fix: GKE autopilot attribution

### DIFF
--- a/catalog/gke-autopilot/cluster/cluster.yaml
+++ b/catalog/gke-autopilot/cluster/cluster.yaml
@@ -17,7 +17,7 @@ metadata: # kpt-merge: config-control/example-us-east4
   name: example-us-east4 # kpt-set: ${cluster-name}
   namespace: config-control # kpt-set: ${platform-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gke-autopilot:gke-autopilot/v0.0.1
+    cnrm.cloud.google.com/blueprint: cnrm/gke-autopilot/v0.0.1
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
     # Remove the default node pool after bootstrapping.
     # Explcit node pool configuration allows for more isolation and makes it

--- a/catalog/gke-autopilot/cluster/container-api.yaml
+++ b/catalog/gke-autopilot/cluster/container-api.yaml
@@ -19,7 +19,7 @@ metadata: # kpt-merge: projects/project-id-cluster-name-container
   name: project-id-cluster-name-container # kpt-set: ${project-id}-${cluster-name}-container
   namespace: projects # kpt-set: ${projects-namespace}
   annotations:
-    cnrm.cloud.google.com/blueprint: cnrm/gke-autopilot:gke-autopilot/v0.0.1
+    cnrm.cloud.google.com/blueprint: cnrm/gke-autopilot/v0.0.1
     cnrm.cloud.google.com/deletion-policy: abandon
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
 spec:


### PR DESCRIPTION
Since GKE autopilot is a single package I don't think colon delimited `gke-autopilot` adds value.