### PR TITLE
fix: reduce setters for GKE blueprint

### DIFF
--- a/catalog/gke/README.md
+++ b/catalog/gke/README.md
@@ -16,10 +16,8 @@ A GKE cluster with a primary node pool. An existing subnet needs to be provided 
 | max-node-count      |                                                              2 | int  |     1 |
 | network-ref         | projects/network-project-id/global/networks/default            | str  |     1 |
 | nodepool-name       | primary                                                        | str  |    11 |
-| platform-namespace  | config-control                                                 | str  |     9 |
 | pods-range-name     | pods                                                           | str  |     1 |
 | project-id          | project-id                                                     | str  |     9 |
-| projects-namespace  | projects                                                       | str  |     1 |
 | security-group      | gke-security-groups@example.com                                | str  |     1 |
 | services-range-name | services                                                       | str  |     1 |
 | subnet-ref          | projects/network-project-id/regions/region/subnetworks/default | str  |     1 |

--- a/catalog/gke/cluster/README.md
+++ b/catalog/gke/cluster/README.md
@@ -14,10 +14,8 @@ A GKE cluster with public masters and private nodes
 | location            | us-east4                                                       | str  |     1 |
 | master-ip-range     | 10.254.0.0/28                                                  | str  |     1 |
 | network-ref         | projects/network-project-id/global/networks/default            | str  |     1 |
-| platform-namespace  | config-control                                                 | str  |     1 |
 | pods-range-name     | pods                                                           | str  |     1 |
 | project-id          | project-id                                                     | str  |     4 |
-| projects-namespace  | projects                                                       | str  |     1 |
 | security-group      | gke-security-groups@example.com                                | str  |     1 |
 | services-range-name | services                                                       | str  |     1 |
 | subnet-ref          | projects/network-project-id/regions/region/subnetworks/default | str  |     1 |
@@ -31,7 +29,7 @@ This package has no sub-packages.
 |        File        |                 APIVersion                 |       Kind       |               Name                |   Namespace    |
 |--------------------|--------------------------------------------|------------------|-----------------------------------|----------------|
 | cluster.yaml       | container.cnrm.cloud.google.com/v1beta1    | ContainerCluster | example-us-east4                  | config-control |
-| container-api.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service          | project-id-cluster-name-container | projects       |
+| container-api.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service          | project-id-cluster-name-container | config-control |
 
 ## Resource References
 

--- a/catalog/gke/cluster/cluster.yaml
+++ b/catalog/gke/cluster/cluster.yaml
@@ -15,7 +15,7 @@ apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerCluster
 metadata:
   name: example-us-east4 # kpt-set: ${cluster-name}
-  namespace: config-control # kpt-set: ${platform-namespace}
+  namespace: config-control
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/gke:gke-cluster/v0.4.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}

--- a/catalog/gke/cluster/container-api.yaml
+++ b/catalog/gke/cluster/container-api.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   # Use a unique name to avoid overlap with other cluster package instances.
   name: project-id-cluster-name-container # kpt-set: ${project-id}-${cluster-name}-container
-  namespace: projects # kpt-set: ${projects-namespace}
+  namespace: config-control
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/gke:gke-cluster/v0.4.0
     cnrm.cloud.google.com/deletion-policy: abandon

--- a/catalog/gke/cluster/setters.yaml
+++ b/catalog/gke/cluster/setters.yaml
@@ -26,12 +26,6 @@ data:
   network-ref: projects/network-project-id/global/networks/default
   # The reference to the subnet
   subnet-ref: projects/network-project-id/regions/region/subnetworks/default
-  # The namespace in which to manage cluster resources
-  platform-namespace: config-control
-  # The project in which to manage cluster resources
-  project-id: project-id
-  # The namespace in which to manage service enablement resources
-  projects-namespace: projects
   # The group in which to manage the list of groups that can be used for RBAC.
   # Must be named exactly 'gke-security-groups'.
   security-group: gke-security-groups@example.com

--- a/catalog/gke/nodepools/primary/README.md
+++ b/catalog/gke/nodepools/primary/README.md
@@ -8,15 +8,13 @@ A GKE node pool with a dedicated service account
 
 ## Setters
 
-|        Name        |      Value       | Type | Count |
-|--------------------|------------------|------|-------|
-| cluster-name       | example-us-east4 | str  |    11 |
-| location           | us-east4         | str  |     1 |
-| max-node-count     |                2 | int  |     1 |
-| nodepool-name      | primary          | str  |    11 |
-| platform-namespace | config-control   | str  |     8 |
-| project-id         | project-id       | str  |     5 |
-| projects-namespace | projects         | str  |     0 |
+|      Name      |      Value       | Type | Count |
+|----------------|------------------|------|-------|
+| cluster-name   | example-us-east4 | str  |    11 |
+| location       | us-east4         | str  |     1 |
+| max-node-count |                2 | int  |     1 |
+| nodepool-name  | primary          | str  |    11 |
+| project-id     | project-id       | str  |     5 |
 
 ## Sub-packages
 

--- a/catalog/gke/nodepools/primary/node-iam.yaml
+++ b/catalog/gke/nodepools/primary/node-iam.yaml
@@ -16,7 +16,7 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
   name: gke-example-us-east4-primary # kpt-set: gke-${cluster-name}-${nodepool-name}
-  namespace: config-control # kpt-set: ${platform-namespace}
+  namespace: config-control
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/gke:gke-nodepool/v0.4.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
@@ -28,14 +28,14 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
   name: logwriter-gke-example-us-east4-primary # kpt-set: logwriter-gke-${cluster-name}-${nodepool-name}
-  namespace: config-control # kpt-set: ${platform-namespace}
+  namespace: config-control
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/gke:gke-nodepool/v0.4.0
 spec:
   memberFrom:
     serviceAccountRef:
       name: gke-example-us-east4-primary # kpt-set: gke-${cluster-name}-${nodepool-name}
-      namespace: config-control # kpt-set: ${platform-namespace}
+      namespace: config-control
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -47,14 +47,14 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
   name: metricwriter-gke-example-us-east4-primary # kpt-set: metricwriter-gke-${cluster-name}-${nodepool-name}
-  namespace: config-control # kpt-set: ${platform-namespace}
+  namespace: config-control
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/gke:gke-nodepool/v0.4.0
 spec:
   memberFrom:
     serviceAccountRef:
       name: gke-example-us-east4-primary # kpt-set: gke-${cluster-name}-${nodepool-name}
-      namespace: config-control # kpt-set: ${platform-namespace}
+      namespace: config-control
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -66,14 +66,14 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
   name: artifactreader-gke-example-us-east4-primary # kpt-set: artifactreader-gke-${cluster-name}-${nodepool-name}
-  namespace: config-control # kpt-set: ${platform-namespace}
+  namespace: config-control
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/gke:gke-nodepool/v0.4.0
 spec:
   memberFrom:
     serviceAccountRef:
       name: gke-example-us-east4-primary # kpt-set: gke-${cluster-name}-${nodepool-name}
-      namespace: config-control # kpt-set: ${platform-namespace}
+      namespace: config-control
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project

--- a/catalog/gke/nodepools/primary/nodepool.yaml
+++ b/catalog/gke/nodepools/primary/nodepool.yaml
@@ -15,7 +15,7 @@ apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
 metadata:
   name: example-us-east4-primary # kpt-set: ${cluster-name}-${nodepool-name}
-  namespace: config-control # kpt-set: ${platform-namespace}
+  namespace: config-control
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/gke:gke-nodepool/v0.4.0
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}

--- a/catalog/gke/nodepools/primary/setters.yaml
+++ b/catalog/gke/nodepools/primary/setters.yaml
@@ -24,9 +24,3 @@ data:
   max-node-count: "2"
   # The name of this node pool
   nodepool-name: primary
-  # The namespace in which to manage cluster resources
-  platform-namespace: config-control
-  # The project in which to manage cluster resources
-  project-id: project-id
-  # The namespace in which to manage service enablement resources
-  projects-namespace: projects

--- a/catalog/gke/setters.yaml
+++ b/catalog/gke/setters.yaml
@@ -26,12 +26,6 @@ data:
   network-ref: projects/network-project-id/global/networks/default
   # The reference to the subnet
   subnet-ref: projects/network-project-id/regions/region/subnetworks/default
-  # The namespace in which to manage cluster resources
-  platform-namespace: config-control
-  # The project in which to manage cluster resources
-  project-id: project-id
-  # The namespace in which to manage service enablement resources
-  projects-namespace: projects
   # The private IP range name for pods to use, this range must already exist
   pods-range-name: pods
   # The private IP range name for services to use, this range must already exist


### PR DESCRIPTION
Remove setters for

- project-id
- namespace

set-project-id function needs to be run imperatively e.g.:

`kpt fn eval --include-meta-resources --image gcr.io/kpt-fn/set-project-id:v0.2.0 -- 'project-id=$PROJECT_ID'`

Before `kpt fn render`