### PR TITLE
Support the ability to set project name separate from project ID

### DIFF
--- a/catalog/project/README.md
+++ b/catalog/project/README.md
@@ -17,7 +17,8 @@ Config Connector.
 | management-namespace  | config-control        | str  |     2 |
 | management-project-id | management-project-id | str  |     5 |
 | networking-namespace  | networking            | str  |     1 |
-| project-id            | project-id            | str  |    18 |
+| project-id            | project-id            | str  |    17 |
+| project-name          | project-name          | str  |     1 |
 | projects-namespace    | projects              | str  |     3 |
 
 ## Sub-packages

--- a/catalog/project/project.yaml
+++ b/catalog/project/project.yaml
@@ -20,7 +20,7 @@ metadata:
     cnrm.cloud.google.com/auto-create-network: "false"
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone:project/v0.4.2
 spec:
-  name: project-id # kpt-set: ${project-id}
+  name: project-name # kpt-set: ${project-name}
   billingAccountRef:
     external: "AAAAAA-BBBBBB-CCCCCC" # kpt-set: ${billing-account-id}
   folderRef:

--- a/catalog/project/setters.yaml
+++ b/catalog/project/setters.yaml
@@ -18,6 +18,7 @@ metadata:
 data:
   folder-name: name.of.folder
   project-id: project-id
+  project-name: project-name
   # These defaults can be kept
   folder-namespace: hierarchy
   networking-namespace: networking


### PR DESCRIPTION
the project blueprint currently treats project name and ID synonymously. This is unintended behavior since project ID is globally unique but display name does not need to be.