### PR TITLE
Set separate project & networking namespaces

### DIFF
--- a/catalog/networking/svpc-service-project/README.md
+++ b/catalog/networking/svpc-service-project/README.md
@@ -8,11 +8,12 @@ A service project to attach to a Shared VPC
 
 ## Setters
 
-|      Name       |    Value     | Type | Count |
-|-----------------|--------------|------|-------|
-| host-project-id | host-project | str  |     1 |
-| namespace       | projects     | str  |     2 |
-| project-id      | project-id   | str  |     2 |
+|         Name         |    Value     | Type | Count |
+|----------------------|--------------|------|-------|
+| host-project-id      | host-project | str  |     1 |
+| networking-namespace | networking   | str  |     1 |
+| project-id           | project-id   | str  |     2 |
+| projects-namespace   | projects     | str  |     1 |
 
 ## Sub-packages
 

--- a/catalog/networking/svpc-service-project/serviceproject.yaml
+++ b/catalog/networking/svpc-service-project/serviceproject.yaml
@@ -15,11 +15,11 @@ apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSharedVPCServiceProject
 metadata:
   name: project-id-svpc-service # kpt-set: ${project-id}-svpc-service
-  namespace: networking # kpt-set: ${namespace}
+  namespace: networking # kpt-set: ${networking-namespace}
   annotations:
     cnrm.cloud.google.com/project-id: host-project # kpt-set: ${host-project-id}
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.4.0
 spec:
   projectRef:
     name: project-id # kpt-set: ${project-id}
-    namespace: projects # kpt-set: ${namespace}
+    namespace: projects # kpt-set: ${projects-namespace}

--- a/catalog/networking/svpc-service-project/setters.yaml
+++ b/catalog/networking/svpc-service-project/setters.yaml
@@ -16,6 +16,7 @@ kind: ConfigMap
 metadata:
   name: setters
 data:
-  namespace: projects
+  networking-namespace: networking
+  projects-namespace: projects
   host-project-id: host-project
   project-id: project-id


### PR DESCRIPTION
Use separate setters for project and networking namespaces when
attaching shared vpc service projects. This blueprint needs to make a
project reference and also allow the networking service account with
xpnAdmin permissions to be used.