### PR TITLE
Add ignore-clusterless annotations to landing-zone-lite

### DIFF
--- a/catalog/landing-zone-lite/namespaces/hierarchy.yaml
+++ b/catalog/landing-zone-lite/namespaces/hierarchy.yaml
@@ -46,6 +46,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
   resourceRef:
     name: hierarchy-sa

--- a/catalog/landing-zone-lite/namespaces/projects.yaml
+++ b/catalog/landing-zone-lite/namespaces/projects.yaml
@@ -126,6 +126,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.1.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
   resourceRef:
     name: projects-sa


### PR DESCRIPTION
Workload identity bindings should be ignored in landing-zone-lite blueprint as well