### PR TITLE
Add ignore-clusterless to project blueprint resources

### DIFF
--- a/catalog/project/kcc-namespace/kcc-project-owner.yaml
+++ b/catalog/project/kcc-namespace/kcc-project-owner.yaml
@@ -20,6 +20,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.4.2
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1

--- a/catalog/project/kcc-namespace/kcc.yaml
+++ b/catalog/project/kcc-namespace/kcc.yaml
@@ -31,6 +31,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.4.2
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
+    cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
   displayName: kcc-project-id # kpt-set: kcc-${project-id}
 ---


### PR DESCRIPTION
It's possible that we encounter service account limits if the customer creates too many projects (>100). Add ignore-clusterless annotation to the project blueprint resources that don't make much sense to avoid hitting this limit.