### PR TITLE
feat: gitops multirepo update

### DIFF
--- a/catalog/gitops/configsync/README.md
+++ b/catalog/gitops/configsync/README.md
@@ -30,15 +30,17 @@ This package has no sub-packages.
 
 ## Resources
 
-|          File          |            APIVersion             |       Kind        |                    Name                    |   Namespace    |
-|------------------------|-----------------------------------|-------------------|--------------------------------------------|----------------|
-| config-management.yaml | configmanagement.gke.io/v1        | ConfigManagement  | config-management                          |                |
-| configsync-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1 | IAMServiceAccount | sync-cluster-name                          | config-control |
-| configsync-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1 | IAMPartialPolicy  | sync-cluster-name                          | config-control |
-| configsync-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1 | IAMPartialPolicy  | source-reader-sync-cluster-name-project-id | config-control |
+|          File          |            APIVersion             |       Kind        |                    Name                    |        Namespace         |
+|------------------------|-----------------------------------|-------------------|--------------------------------------------|--------------------------|
+| config-management.yaml | configmanagement.gke.io/v1        | ConfigManagement  | config-management                          |                          |
+| configsync-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1 | IAMServiceAccount | sync-cluster-name                          | config-control           |
+| configsync-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1 | IAMPartialPolicy  | sync-cluster-name                          | config-control           |
+| configsync-iam.yaml    | iam.cnrm.cloud.google.com/v1beta1 | IAMPartialPolicy  | source-reader-sync-cluster-name-project-id | config-control           |
+| rootsync.yaml          | configsync.gke.io/v1beta1         | RootSync          | root-sync                                  | config-management-system |
 
 ## Resource References
 
+- RootSync
 - [ConfigManagement](https://cloud.google.com/anthos-config-management/docs/configmanagement-fields)
 - [IAMPartialPolicy](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampartialpolicy)
 - [IAMServiceAccount](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount)

--- a/catalog/gitops/configsync/config-management.yaml
+++ b/catalog/gitops/configsync/config-management.yaml
@@ -19,12 +19,4 @@ metadata:
   name: config-management
 spec:
   clusterName: cluster-name # kpt-set: ${cluster-name}
-  enableMultiRepo: false
-  git:
-    gcpServiceAccountEmail: sync-cluster-name@project-id.iam.gserviceaccount.com # kpt-set: sync-${cluster-name}@${project-id}.iam.gserviceaccount.com
-    policyDir: config # kpt-set: ${configsync-dir}
-    secretType: gcpserviceaccount
-    syncBranch: main
-    syncRepo: https://source.developers.google.com/p/project-id/r/deployment-repo # kpt-set: https://source.developers.google.com/p/${project-id}/r/${deployment-repo}
-    syncRevision: HEAD
-  sourceFormat: unstructured
+  enableMultiRepo: true

--- a/catalog/gitops/configsync/configsync-iam.yaml
+++ b/catalog/gitops/configsync/configsync-iam.yaml
@@ -41,7 +41,7 @@ spec:
   bindings:
     - role: roles/iam.workloadIdentityUser
       members:
-        - member: serviceAccount:project-id.svc.id.goog[config-management-system/importer] # kpt-set: serviceAccount:${project-id}.svc.id.goog[config-management-system/importer]
+        - member: serviceAccount:project-id.svc.id.goog[config-management-system/root-reconciler] # kpt-set: serviceAccount:${project-id}.svc.id.goog[config-management-system/root-reconciler]
 ---
 # Allow Config Sync GSA to read from CSR repos in the CSR project
 apiVersion: iam.cnrm.cloud.google.com/v1beta1

--- a/catalog/gitops/configsync/rootsync.yaml
+++ b/catalog/gitops/configsync/rootsync.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: configsync.gke.io/v1beta1
+kind: RootSync
+metadata:
+  name: root-sync
+  namespace: config-management-system
+spec:
+  sourceFormat: unstructured
+  git:
+    repo: https://source.developers.google.com/p/project-id/r/deployment-repo # kpt-set: https://source.developers.google.com/p/${project-id}/r/${deployment-repo}
+    revision: HEAD
+    branch: main
+    dir: config # kpt-set: ${configsync-dir}
+    auth: gcpserviceaccount
+    gcpServiceAccountEmail: sync-cluster-name@project-id.iam.gserviceaccount.com # kpt-set: sync-${cluster-name}@${project-id}.iam.gserviceaccount.com


### PR DESCRIPTION
Update gitops blueprint to use multirepo mode. Marking as draft until 1.11 rolls out in CC