### PR TITLE
fix: remove gitops ConfigManagement syncRevision field

### DIFF
--- a/catalog/gitops/configsync/config-management.yaml
+++ b/catalog/gitops/configsync/config-management.yaml
@@ -26,5 +26,4 @@ spec:
     secretType: gcpserviceaccount
     syncBranch: main
     syncRepo: https://source.developers.google.com/p/project-id/r/deployment-repo # kpt-set: https://source.developers.google.com/p/${project-id}/r/${deployment-repo}
-    syncRev: HEAD
   sourceFormat: unstructured

--- a/catalog/gitops/configsync/config-management.yaml
+++ b/catalog/gitops/configsync/config-management.yaml
@@ -26,5 +26,5 @@ spec:
     secretType: gcpserviceaccount
     syncBranch: main
     syncRepo: https://source.developers.google.com/p/project-id/r/deployment-repo # kpt-set: https://source.developers.google.com/p/${project-id}/r/${deployment-repo}
-    syncRevision: HEAD
+    syncRev: HEAD
   sourceFormat: unstructured


### PR DESCRIPTION
Looks like this `syncRevision` field should have been `syncRev` per https://cloud.google.com/anthos-config-management/docs/configmanagement-fields#configuring-git-repo. 

`syncRev` defaults to `HEAD` so I don't think there is value in keeping it in config.

```
error: error validating "gitops/configsync/config-management.yaml": error validating data: ValidationError(ConfigManagement.spec.git): unknown field "syncRevision" in io.gke.configmanagement.v1.ConfigManagement.spec.git; if you choose to ignore these errors, turn validation off with --validate=false
```