### PR TITLE
feat: add one year retention policy to log export buckets

### DIFF
--- a/catalog/log-export/folder/storage-export/export.yaml
+++ b/catalog/log-export/folder/storage-export/export.yaml
@@ -54,3 +54,6 @@ spec:
   bucketPolicyOnly: false # kpt-set: ${bucket-policy-only}
   location: US # kpt-set: ${location}
   storageClass: MULTI_REGIONAL # kpt-set: ${storage-class}
+  retentionPolicy:
+    retentionPeriod: 31536000
+    isLocked: false

--- a/catalog/log-export/org/storage-export/export.yaml
+++ b/catalog/log-export/org/storage-export/export.yaml
@@ -55,3 +55,6 @@ spec:
   bucketPolicyOnly: false # kpt-set: ${bucket-policy-only}
   location: US # kpt-set: ${location}
   storageClass: MULTI_REGIONAL # kpt-set: ${storage-class}
+  retentionPolicy:
+    retentionPeriod: 31536000
+    isLocked: false


### PR DESCRIPTION
This sets a default one year retention policy for the log export buckets. Optionally retention lock can be enabled for users with stricter compliance requirements.