### PR TITLE
chore: add IAMAuditConfig example

### DIFF
--- a/examples/iam-audit-config/Kptfile
+++ b/examples/iam-audit-config/Kptfile
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: iamauditconfig-example
+  annotations:
+    blueprints.cloud.google.com/title: Org IAMAuditConfig example
+    config.kubernetes.io/local-config: "true"
+info:
+  description: An example showing how to configure IAMAuditConfig for an organization.
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
+      configPath: setters.yaml

--- a/examples/iam-audit-config/README.md
+++ b/examples/iam-audit-config/README.md
@@ -1,0 +1,69 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# Org IAMAuditConfig example
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+An example showing how to configure IAMAuditConfig for an organization.
+
+## Setters
+
+|   Name    |  Value  | Type | Count |
+|-----------|---------|------|-------|
+| namespace | logging | str  |     1 |
+| org-id    |     123 | str  |     2 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|    File    |            APIVersion             |      Kind      |        Name        | Namespace |
+|------------|-----------------------------------|----------------|--------------------|-----------|
+| audit.yaml | iam.cnrm.cloud.google.com/v1beta1 | IAMAuditConfig | 123-iamauditconfig | logging   |
+
+## Resource References
+
+- [IAMAuditConfig](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamauditconfig)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/examples/iam-audit-configiam-audit-config@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd "./iam-audit-config/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}"
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/examples/iam-audit-config/audit.yaml
+++ b/examples/iam-audit-config/audit.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMAuditConfig
+metadata:
+  name: 123-iamauditconfig # kpt-set: ${org-id}-iamauditconfig
+  namespace: logging # kpt-set: ${namespace}
+spec:
+  service: allServices
+  auditLogConfigs:
+    - logType: ADMIN_READ
+  resourceRef:
+    kind: Organization
+    external: "123" # kpt-set: ${org-id}

--- a/examples/iam-audit-config/setters.yaml
+++ b/examples/iam-audit-config/setters.yaml
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  org-id: 123
+  namespace: logging


### PR DESCRIPTION
Adds an example showing how to configure org level IAMAuditConfig similar to [example-foundation](https://github.com/terraform-google-modules/terraform-example-foundation/blob/8391f1bd4322fec04fda7509b537c5f66cddbbd9/1-org/envs/shared/iam.tf#L25-L44)