### PR TITLE
fix!: replace bucket policy in storage log export with uniform bucket level access

### DIFF
--- a/catalog/log-export/folder/storage-export/README.md
+++ b/catalog/log-export/folder/storage-export/README.md
@@ -8,17 +8,17 @@ A log export on a folder that sinks to Cloud Storage
 
 ## Setters
 
-|           Name           |       Value        | Type | Count |
-|--------------------------|--------------------|------|-------|
-| bucket-policy-only       | false              | bool |     1 |
-| filter                   |                    | str  |     0 |
-| folder-k8s-name          | my.folder.k8s.name | str  |     3 |
-| location                 | US                 | str  |     1 |
-| namespace                | my-namespace       | str  |     3 |
-| project-id               | my-project-id      | str  |     3 |
-| retention-period-seconds |           31536000 | int  |     1 |
-| storage-bucket-name      | my-storage-bucket  | str  |     3 |
-| storage-class            | MULTI_REGIONAL     | str  |     1 |
+|            Name             |       Value        | Type | Count |
+|-----------------------------|--------------------|------|-------|
+| filter                      |                    | str  |     0 |
+| folder-k8s-name             | my.folder.k8s.name | str  |     3 |
+| location                    | US                 | str  |     1 |
+| namespace                   | my-namespace       | str  |     3 |
+| project-id                  | my-project-id      | str  |     3 |
+| retention-period-seconds    |           31536000 | int  |     1 |
+| storage-bucket-name         | my-storage-bucket  | str  |     3 |
+| storage-class               | MULTI_REGIONAL     | str  |     1 |
+| uniform-bucket-level-access | true               | bool |     1 |
 
 ## Sub-packages
 

--- a/catalog/log-export/folder/storage-export/export.yaml
+++ b/catalog/log-export/folder/storage-export/export.yaml
@@ -52,7 +52,7 @@ metadata:
     cnrm.cloud.google.com/force-destroy: "true"
     cnrm.cloud.google.com/project-id: my-project-id # kpt-set: ${project-id}
 spec:
-  bucketPolicyOnly: false # kpt-set: ${bucket-policy-only}
+  uniformBucketLevelAccess: true # kpt-set: ${uniform-bucket-level-access}
   location: US # kpt-set: ${location}
   storageClass: MULTI_REGIONAL # kpt-set: ${storage-class}
   retentionPolicy:

--- a/catalog/log-export/folder/storage-export/setters.yaml
+++ b/catalog/log-export/folder/storage-export/setters.yaml
@@ -17,7 +17,7 @@ metadata:
   name: setters
 data:
   namespace: my-namespace
-  bucket-policy-only: "false"
+  uniform-bucket-level-access: "true"
   filter: ""
   folder-k8s-name: my.folder.k8s.name
   location: US

--- a/catalog/log-export/org/storage-export/README.md
+++ b/catalog/log-export/org/storage-export/README.md
@@ -8,17 +8,17 @@ A log export on a organization that sinks to Cloud Storage
 
 ## Setters
 
-|           Name           |       Value       | Type | Count |
-|--------------------------|-------------------|------|-------|
-| bucket-policy-only       | false             | bool |     1 |
-| filter                   |                   | str  |     0 |
-| location                 | US                | str  |     1 |
-| namespace                | my-namespace      | str  |     3 |
-| org-id                   |      123456789012 | str  |     3 |
-| project-id               | my-project-id     | str  |     3 |
-| retention-period-seconds |          31536000 | int  |     1 |
-| storage-bucket-name      | my-storage-bucket | str  |     3 |
-| storage-class            | MULTI_REGIONAL    | str  |     1 |
+|            Name             |       Value       | Type | Count |
+|-----------------------------|-------------------|------|-------|
+| filter                      |                   | str  |     0 |
+| location                    | US                | str  |     1 |
+| namespace                   | my-namespace      | str  |     3 |
+| org-id                      |      123456789012 | str  |     3 |
+| project-id                  | my-project-id     | str  |     3 |
+| retention-period-seconds    |          31536000 | int  |     1 |
+| storage-bucket-name         | my-storage-bucket | str  |     3 |
+| storage-class               | MULTI_REGIONAL    | str  |     1 |
+| uniform-bucket-level-access | true              | bool |     1 |
 
 ## Sub-packages
 

--- a/catalog/log-export/org/storage-export/export.yaml
+++ b/catalog/log-export/org/storage-export/export.yaml
@@ -53,7 +53,7 @@ metadata:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
     cnrm.cloud.google.com/project-id: my-project-id # kpt-set: ${project-id}
 spec:
-  bucketPolicyOnly: false # kpt-set: ${bucket-policy-only}
+  uniformBucketLevelAccess: true # kpt-set: ${uniform-bucket-level-access}
   location: US # kpt-set: ${location}
   storageClass: MULTI_REGIONAL # kpt-set: ${storage-class}
   retentionPolicy:

--- a/catalog/log-export/org/storage-export/setters.yaml
+++ b/catalog/log-export/org/storage-export/setters.yaml
@@ -17,7 +17,7 @@ metadata:
   name: setters
 data:
   namespace: my-namespace
-  bucket-policy-only: "false"
+  uniform-bucket-level-access: "true"
   filter: ""
   location: US
   org-id: "123456789012"


### PR DESCRIPTION
This also aligns with TF blueprint defaults 
https://github.com/terraform-google-modules/terraform-google-log-export/blob/86d638817306fad77e4756c116ceea976cedb567/modules/storage/variables.tf#L50-L54