### PR TITLE
feat:adds blueprints for log-export with sinks for Cloud Log Buckets

### DIFF
--- a/catalog/log-export/folder/logbucket-export/Kptfile
+++ b/catalog/log-export/folder/logbucket-export/Kptfile
@@ -1,0 +1,12 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: logbucket-export
+  annotations:
+    blueprints.cloud.google.com/title: Cloud Logging Log Bucket Export blueprint
+info:
+  description: A log export on a folder that sinks to Cloud Logging Log Bucket
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.1
+      configPath: setters.yaml

--- a/catalog/log-export/folder/logbucket-export/README.md
+++ b/catalog/log-export/folder/logbucket-export/README.md
@@ -1,0 +1,78 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# Cloud Logging Log Bucket Export blueprint
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+A log export on a folder that sinks to Cloud Logging Log Bucket
+
+## Setters
+
+|        Name         |       Value       | Type | Count |
+|---------------------|-------------------|------|-------|
+| filter              |                   | str  |     0 |
+| folder-id           |      123456789012 | str  |     2 |
+| location            | global            | str  |     2 |
+| log-bucket-k8s-name | my-log-k8s-bucket | str  |     2 |
+| namespace           | my-namespace      | str  |     3 |
+| project-id          | my-project-id     | str  |     4 |
+| retentionDays       |                30 | int  |     1 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|    File     |                 APIVersion                 |       Kind       |              Name              |  Namespace   |
+|-------------|--------------------------------------------|------------------|--------------------------------|--------------|
+| export.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service          | my-project-id-logbucket        | my-namespace |
+| export.yaml | logging.cnrm.cloud.google.com/v1beta1      | LoggingLogSink   | 123456789012-fldrlogbucketsink | my-namespace |
+| export.yaml | logging.cnrm.cloud.google.com/v1beta1      | LoggingLogBucket | my-log-k8s-bucket              | my-namespace |
+
+## Resource References
+
+- [LoggingLogBucket](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogbucket)
+- [LoggingLogSink](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogsink)
+- [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/log-export/folder/logbucket-export@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd "./logbucket-export/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}"
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/log-export/folder/logbucket-export/export.yaml
+++ b/catalog/log-export/folder/logbucket-export/export.yaml
@@ -1,0 +1,59 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# API Activation
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: my-project-id-logbucket # kpt-set: ${project-id}-logbucket
+  namespace: my-namespace # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/project-id: my-project-id # kpt-set: ${project-id}
+spec:
+  resourceID: logging.googleapis.com
+---
+# Org Sink to Log Bucket
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: 123456789012-fldrlogbucketsink # kpt-set: ${folder-id}-fldrlogbucketsink
+  namespace: my-namespace # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+spec:
+  folderRef:
+    external: "123456789012" # kpt-set: ${folder-id}
+  destination:
+    loggingLogBucketRef:
+      external: logging.googleapis.com/projects/my-project-id/locations/global/buckets/my-log-k8s-bucket # kpt-set: logging.googleapis.com/projects/${project-id}/locations/${location}/buckets/${log-bucket-k8s-name}
+  filter: "" # kpt-set: ${filter}
+  includeChildren: true
+---
+# Logging Log Bucket
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogBucket
+metadata:
+  name: my-log-k8s-bucket # kpt-set: ${log-bucket-k8s-name}
+  namespace: my-namespace # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+spec:
+  projectRef:
+    external: "projects/my-project-id" # kpt-set: projects/${project-id}
+  location: "global" # kpt-set: ${location}
+  description: "Log bucket for organization level logs"
+  locked: true
+  retentionDays: 30 # kpt-set: ${retentionDays}

--- a/catalog/log-export/folder/logbucket-export/setters.yaml
+++ b/catalog/log-export/folder/logbucket-export/setters.yaml
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+data:
+  namespace: my-namespace
+  folder-id: "123456789012"
+  project-id: my-project-id
+  log-bucket-k8s-name: my-log-k8s-bucket
+  location: global
+  filter: ""
+  retentionDays: "30"

--- a/catalog/log-export/org/logbucket-export/Kptfile
+++ b/catalog/log-export/org/logbucket-export/Kptfile
@@ -1,0 +1,12 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: logbucket-export
+  annotations:
+    blueprints.cloud.google.com/title: Cloud Logging Log Bucket Export blueprint
+info:
+  description: A log export on an organization that sinks to Cloud Logging Log Bucket
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:v0.1
+      configPath: setters.yaml

--- a/catalog/log-export/org/logbucket-export/README.md
+++ b/catalog/log-export/org/logbucket-export/README.md
@@ -1,0 +1,78 @@
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+# Cloud Logging Log Bucket Export blueprint
+
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:TITLE -->
+<!-- BEGINNING OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->
+A log export on an organization that sinks to Cloud Logging Log Bucket
+
+## Setters
+
+|        Name         |       Value       | Type | Count |
+|---------------------|-------------------|------|-------|
+| filter              |                   | str  |     0 |
+| location            | global            | str  |     2 |
+| log-bucket-k8s-name | my-log-k8s-bucket | str  |     2 |
+| namespace           | my-namespace      | str  |     3 |
+| org-id              |      123456789012 | str  |     2 |
+| project-id          | my-project-id     | str  |     4 |
+| retentionDays       |                30 | int  |     1 |
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+|    File     |                 APIVersion                 |       Kind       |             Name              |  Namespace   |
+|-------------|--------------------------------------------|------------------|-------------------------------|--------------|
+| export.yaml | serviceusage.cnrm.cloud.google.com/v1beta1 | Service          | my-project-id-logbucket       | my-namespace |
+| export.yaml | logging.cnrm.cloud.google.com/v1beta1      | LoggingLogSink   | 123456789012-orglogbucketsink | my-namespace |
+| export.yaml | logging.cnrm.cloud.google.com/v1beta1      | LoggingLogBucket | my-log-k8s-bucket             | my-namespace |
+
+## Resource References
+
+- [LoggingLogBucket](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogbucket)
+- [LoggingLogSink](https://cloud.google.com/config-connector/docs/reference/resource-docs/logging/logginglogsink)
+- [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
+
+## Usage
+
+1.  Clone the package:
+    ```shell
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/log-export/org/logbucket-export@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```shell
+    cd "./logbucket-export/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```shell
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```shell
+    kpt live init --namespace ${NAMESPACE}"
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```shell
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```shell
+    kpt live status --output table --poll-until current
+    ```
+
+<!-- END OF PRE-COMMIT-BLUEPRINT DOCS HOOK:BODY -->

--- a/catalog/log-export/org/logbucket-export/export.yaml
+++ b/catalog/log-export/org/logbucket-export/export.yaml
@@ -1,0 +1,59 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# API Activation
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: my-project-id-logbucket # kpt-set: ${project-id}-logbucket
+  namespace: my-namespace # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/project-id: my-project-id # kpt-set: ${project-id}
+spec:
+  resourceID: logging.googleapis.com
+---
+# Org Sink to Log Bucket
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: 123456789012-orglogbucketsink # kpt-set: ${org-id}-orglogbucketsink
+  namespace: my-namespace # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+spec:
+  organizationRef:
+    external: "123456789012" # kpt-set: ${org-id}
+  destination:
+    loggingLogBucketRef:
+      external: logging.googleapis.com/projects/my-project-id/locations/global/buckets/my-log-k8s-bucket # kpt-set: logging.googleapis.com/projects/${project-id}/locations/${location}/buckets/${log-bucket-k8s-name}
+  filter: "" # kpt-set: ${filter}
+  includeChildren: true
+---
+# Logging Log Bucket
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogBucket
+metadata:
+  name: my-log-k8s-bucket # kpt-set: ${log-bucket-k8s-name}
+  namespace: my-namespace # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+spec:
+  projectRef:
+    external: "projects/my-project-id" # kpt-set: projects/${project-id}
+  location: "global" # kpt-set: ${location}
+  description: "Log bucket for organization level logs"
+  locked: true
+  retentionDays: 30 # kpt-set: ${retentionDays}

--- a/catalog/log-export/org/logbucket-export/setters.yaml
+++ b/catalog/log-export/org/logbucket-export/setters.yaml
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+data:
+  namespace: my-namespace
+  org-id: "123456789012"
+  project-id: my-project-id
+  log-bucket-k8s-name: my-log-k8s-bucket
+  location: global
+  filter: ""
+  retentionDays: "30"


### PR DESCRIPTION
Two new blueprints for export logs to [Cloud Log Buckets](https://cloud.google.com/logging/docs/routing/overview#buckets)