### PR TITLE
fix: reduce setters for ACM on GKE blueprint

### DIFF
--- a/catalog/anthos-cluster/acm/README.md
+++ b/catalog/anthos-cluster/acm/README.md
@@ -6,7 +6,6 @@ A blueprint to install Anthos Config Management (ACM) on an existing GKE cluster
 
 ```
 Setter              Usages
-acm-version         0
 cluster-name        16
 location            2
 platform-namespace  8

--- a/catalog/anthos-cluster/acm/config-mgmt-csr.yaml
+++ b/catalog/anthos-cluster/acm/config-mgmt-csr.yaml
@@ -28,7 +28,6 @@ spec:
   featureRef:
     name: feature-name # kpt-set: feat-acm-${cluster-name}
   configmanagement:
-    version: 1.9.0 #kpt-set: ${acm-version}
     configSync:
       sourceFormat: unstructured
       git:

--- a/catalog/anthos-cluster/acm/setters.yaml
+++ b/catalog/anthos-cluster/acm/setters.yaml
@@ -28,8 +28,6 @@ data:
   sync-repo: https://source.developers.google.com/p/project_id/r/repo
   # The directory in the repository to pull configs from e.g. config/root
   policy-dir: config/root
-  # ACM version to install
-  acm-version: 1.9.0
   # The reference for the repo e.g. projects/${project}/repos/${name}. Used to grant access to the ACM Service Account
   sync-repo-ref: projects/project-id/repos/repo-name
   # The project in which to manage cluster resources


### PR DESCRIPTION
Remove setter for
* acm-version 

The latest version of ACM will be used, however users can in-place edit if needed.

Fixes #196 