### PR TITLE
feat: add cluster-name validator, update README

### DIFF
--- a/catalog/gitops/configsync/Kptfile
+++ b/catalog/gitops/configsync/Kptfile
@@ -16,7 +16,13 @@ info:
     2.  Manage plain KRM or manually rendered blueprints
     3.  Automatically apply your config changes to your Config Controller
         cluster on merge
+
+    NOTE: cluster-name must not exceed 25 characters in length, as it is
+    included in the service account ID which has a maximum character length.
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/apply-setters:v0.1
       configPath: setters.yaml
+  validators:
+    - image: gcr.io/kpt-fn/starlark:v0.4
+      configPath: validation.yaml

--- a/catalog/gitops/configsync/README.md
+++ b/catalog/gitops/configsync/README.md
@@ -14,6 +14,9 @@ After installing this blueprint, you will be able to:
 3.  Automatically apply your config changes to your Config Controller
     cluster on merge
 
+NOTE: cluster-name must not exceed 25 characters in length, as it is
+included in the service account ID which has a maximum character length.
+
 ## Setters
 
 |      Name       |      Value      | Type | Count |

--- a/catalog/gitops/configsync/validation.yaml
+++ b/catalog/gitops/configsync/validation.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,16 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: v1
-kind: ConfigMap
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
 metadata:
-  name: setters
+  name: validate-cluster-name-length
   annotations:
-    config.kubernetes.io/local-config: "true"
-data:
-  namespace: config-control
-  # cluster-name must not exceed 25 characters in length
-  cluster-name: cluster-name
-  configsync-dir: config
-  deployment-repo: deployment-repo
-  project-id: project-id
+    config.kubernetes.io/local-config: 'true'
+source: |
+  for resource in ctx.resource_list["items"]:
+    if resource["kind"] == "IAMServiceAccount" and \
+    len(resource["metadata"]["name"]) > 30:
+      fail("cluster-name cannot exceed 25 characters in length:", \
+      len(resource["metadata"]["name"])-5)


### PR DESCRIPTION
* Limits cluster-name to 25 character for maximum service account ID length
* Update README with cluster-name length
* Add validator for cluster-name-length, displays cluster-name length on failure

b/241421051