### PR TITLE
chore: add KRM schema validation

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -1,0 +1,29 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Lint check"
+on: [push]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: |
+          docker run --rm \
+          -e DOCKER_HOST_PATH=/home/runner/work/blueprints/blueprints \
+          --network=host \
+          -v /home/runner/work/blueprints/blueprints:/workspace \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          gcr.io/cloud-foundation-cicd/cft/developer-tools-krm:1.8 \
+          ./utils/check_lint.sh

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -23,7 +23,7 @@ presubmits:
       timeout: 30m
     spec:
       containers:
-        - image: gcr.io/cloud-foundation-cicd/cft/developer-tools-krm:1.3
+        - image: gcr.io/cloud-foundation-cicd/cft/developer-tools-krm:1.8
           securityContext:
             privileged: true
           command: ["/usr/local/bin/prow_entrypoint.sh"]

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -18,6 +18,7 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
     cluster: build-blueprints
     decoration_config:
       timeout: 30m

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -29,6 +29,10 @@ presubmits:
             privileged: true
           command: ["/usr/local/bin/prow_entrypoint.sh"]
           args: ["utils/check_lint.sh"]
+          resources:
+            requests:
+              memory: 8Gi
+              cpu: 2
   - name: test-int
     always_run: true
     decorate: true

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -13,26 +13,6 @@
 # limitations under the License.
 
 presubmits:
-  - name: lint
-    always_run: true
-    decorate: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    cluster: build-blueprints
-    decoration_config:
-      timeout: 30m
-    spec:
-      containers:
-        - image: gcr.io/cloud-foundation-cicd/cft/developer-tools-krm:1.8
-          securityContext:
-            privileged: true
-          command: ["/usr/local/bin/prow_entrypoint.sh"]
-          args: ["utils/check_lint.sh"]
-          resources:
-            requests:
-              memory: 8Gi
-              cpu: 2
   - name: test-int
     always_run: true
     decorate: true

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 
 SHELL := /usr/bin/env bash
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.3
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.8
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools-krm
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
@@ -22,6 +22,7 @@ REGISTRY_URL := gcr.io/cloud-foundation-cicd
 docker_check_lint:
 	docker run --rm -it \
 		-e DOCKER_HOST_PATH=$(CURDIR) \
+		--network=host \
 		-v $(CURDIR):/workspace \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
@@ -40,6 +41,7 @@ docker_fix_lint:
 .PHONY: docker_run
 docker_run:
 	docker run --rm -it \
+		--network=host \
 		-e ORG_ID \
 		-e FOLDER_ID \
 		-e BILLING_ACCOUNT \

--- a/catalog/landing-zone/services.yaml
+++ b/catalog/landing-zone/services.yaml
@@ -19,7 +19,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone-lite/v0.5.1
     cnrm.cloud.google.com/deletion-policy: "abandon"
-    config.kubernetes.io/local-config: true
+    config.kubernetes.io/local-config: "true"
 spec:
   services:
     - cloudbilling.googleapis.com

--- a/examples/dual-svpc/vpc-shared-restricted/vpcsc-perimeter/perimeter.yaml
+++ b/examples/dual-svpc/vpc-shared-restricted/vpcsc-perimeter/perimeter.yaml
@@ -19,14 +19,15 @@ metadata: # kpt-merge: networking/spcregionperimeter
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone:networking/v0.4.0,kpt-pkg-fn-live
 spec:
-  resources:
-    - projectRef:
-        external: projects/123 # kpt-set: projects/${project-number}
-  accessLevels:
-    - name: alp_dev_members # kpt-set: alp_${env}_members
-  restrictedServices: # kpt-set: ${restricted-services}
-    - "storage.googleapis.com"
-    - "bigquery.googleapis.com"
+  spec:
+    resources:
+      - projectRef:
+          external: projects/123 # kpt-set: projects/${project-number}
+    accessLevels:
+      - name: alp_dev_members # kpt-set: alp_${env}_members
+    restrictedServices: # kpt-set: ${restricted-services}
+      - "storage.googleapis.com"
+      - "bigquery.googleapis.com"
   accessPolicyRef:
     external: accessPolicies/123 # kpt-set: accessPolicies/${access-context-manager-policy-id}
   description: Service Perimeter managed by Config Connector

--- a/utils/lint.sh
+++ b/utils/lint.sh
@@ -125,7 +125,7 @@ function init_schema_check(){
 
     # re create kind cluster
     kind delete cluster --name yaml-validator-cluster
-    kind create cluster --name yaml-validator-cluster
+    kind create cluster --name yaml-validator-cluster --retain || kind export logs $ARTIFACTS
  
     # create namespaces used in blueprints
     for ns in config-control \

--- a/utils/lint.sh
+++ b/utils/lint.sh
@@ -125,7 +125,7 @@ function init_schema_check(){
 
     # re create kind cluster
     kind delete cluster --name yaml-validator-cluster
-    kind create cluster --name yaml-validator-cluster --retain || kind export logs $ARTIFACTS
+    kind create cluster --name yaml-validator-cluster --retain || kind export logs --name yaml-validator-cluster $ARTIFACTS
  
     # create namespaces used in blueprints
     for ns in config-control \

--- a/utils/lint.sh
+++ b/utils/lint.sh
@@ -125,7 +125,7 @@ function init_schema_check(){
 
     # re create kind cluster
     kind delete cluster --name yaml-validator-cluster
-    kind create cluster --name yaml-validator-cluster --retain || kind export logs --name yaml-validator-cluster $ARTIFACTS
+    kind create cluster --name yaml-validator-cluster
  
     # create namespaces used in blueprints
     for ns in config-control \
@@ -178,8 +178,8 @@ function check_schema() {
             done
 
             kpt live init "${child}" &> /dev/null
-            kptOp=$(kpt live apply "${child}" --dry-run --server-side --install-resource-group --output json)
-            passed=$(echo "${kptOp}" | jq 'select(.type == "summary")' | jq 'if .failed == 0 then true else false end')
+            kptOp=$(kpt live apply "${child}" --dry-run --server-side --install-resource-group --inventory-policy adopt --output json || echo "{}")
+            passed=$(echo "${kptOp}" | jq 'select(.eventType == "completed") | if .failedCount == 0 then true else false end')
             if $passed; then
               echo "${child} passed"
             else


### PR DESCRIPTION
This adds schema validation for all KRM blueprints and examples by applying CRDs to a kind cluster and performing server side dry run apply. Some other fixes include
- remove include meta flag which is not used in newer kpt versions
- found an invalid schema in one of the examples which was fixed

There were some complexities getting kind to work inside a prow pod and after discussing with engprod, I switched CI for lint to GHA as we don't need any auth.

b/255631955 and go/fs-automated-validation